### PR TITLE
Export io-ts-types helpers from module subpaths

### DIFF
--- a/.changeset/ten-dodos-report.md
+++ b/.changeset/ten-dodos-report.md
@@ -1,0 +1,5 @@
+---
+"@model-ts/core": patch
+---
+
+Export io-ts-types from module subpaths instead of package barrel

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -3,25 +3,25 @@ import * as t from "io-ts"
 import { clone } from "io-ts-types/lib/clone"
 
 // Curated set of io-ts-types helpers exposed through `t`.
+export { BigIntFromString } from "io-ts-types/lib/BigIntFromString"
+export { BooleanFromNumber } from "io-ts-types/lib/BooleanFromNumber"
+export { BooleanFromString } from "io-ts-types/lib/BooleanFromString"
+export { DateFromISOString } from "io-ts-types/lib/DateFromISOString"
+export { DateFromNumber } from "io-ts-types/lib/DateFromNumber"
+export { DateFromUnixTime } from "io-ts-types/lib/DateFromUnixTime"
+export { IntFromString } from "io-ts-types/lib/IntFromString"
 export {
-  BigIntFromString,
-  BooleanFromNumber,
-  BooleanFromString,
-  DateFromISOString,
-  DateFromNumber,
-  DateFromUnixTime,
-  IntFromString,
   Json,
   JsonArray,
   JsonFromString,
   JsonRecord,
-  NonEmptyString,
-  nonEmptyArray,
-  NumberFromString,
-  readonlyNonEmptyArray,
-  withFallback,
-  withMessage,
-} from "io-ts-types"
+} from "io-ts-types/lib/JsonFromString"
+export { NonEmptyString } from "io-ts-types/lib/NonEmptyString"
+export { nonEmptyArray } from "io-ts-types/lib/nonEmptyArray"
+export { NumberFromString } from "io-ts-types/lib/NumberFromString"
+export { readonlyNonEmptyArray } from "io-ts-types/lib/readonlyNonEmptyArray"
+export { withFallback } from "io-ts-types/lib/withFallback"
+export { withMessage } from "io-ts-types/lib/withMessage"
 
 /**
  * Adapted from https://github.com/gcanti/io-ts-types/blob/master/src/withValidate.ts


### PR DESCRIPTION
## Summary
- Re-export the curated `io-ts-types` helpers from their individual `lib/*` subpaths in `packages/core/src/types.ts`
- Keep the public `t` surface unchanged while avoiding the package barrel
- Add a changeset for the `@model-ts/core` patch release

## Testing
- Not run (not requested)