### PR TITLE
Migrate DynamoDB and EventBridge to AWS SDK v3

### DIFF
--- a/.changeset/wicked-badgers-attack.md
+++ b/.changeset/wicked-badgers-attack.md
@@ -1,0 +1,6 @@
+---
+"@model-ts/dynamodb": major
+"@model-ts/eventbridge": major
+---
+
+Move to AWS SDK v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,22 +1,59 @@
 name: CI
 on: [pull_request]
 jobs:
+  build:
+    name: "build"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set Node.js 20.x
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20.x
+          cache: yarn
+
+      - name: Install Dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Build
+        run: yarn build
+
   test_core:
     name: "test:core"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v4
 
-      - name: Set Node.js 12.x
-        uses: actions/setup-node@master
+      - name: Set Node.js 20.x
+        uses: actions/setup-node@v4
         with:
-          node-version: 12.x
+          node-version: 20.x
+          cache: yarn
 
       - name: Install Dependencies
-        run: yarn
+        run: yarn install --frozen-lockfile
 
       - name: Test
         run: yarn workspace @model-ts/core test
+
+  test_eventbridge:
+    name: "test:eventbridge"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set Node.js 20.x
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20.x
+          cache: yarn
+
+      - name: Install Dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Test
+        run: yarn workspace @model-ts/eventbridge test
 
   test_dynamodb:
     name: "test:dynamodb"
@@ -27,21 +64,19 @@ jobs:
         ports:
           - 8000:8000
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v4
 
-      - name: Set Node.js 12.x
-        uses: actions/setup-node@master
+      - name: Set Node.js 20.x
+        uses: actions/setup-node@v4
         with:
-          node-version: 12.x
+          node-version: 20.x
+          cache: yarn
 
       - name: Install Dependencies
-        run: yarn install --focus
-        working-directory: packages/dynamodb
+        run: yarn install --frozen-lockfile
 
       - name: Test
-        run: yarn test
-        working-directory: packages/dynamodb
+        run: yarn workspace @model-ts/dynamodb test
 
       - name: Test (memory)
-        run: yarn test:memory
-        working-directory: packages/dynamodb
+        run: yarn workspace @model-ts/dynamodb test:memory

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,9 @@ jobs:
       - name: Install Dependencies
         run: yarn install --frozen-lockfile
 
+      - name: Build Core
+        run: yarn workspace @model-ts/core build
+
       - name: Test
         run: yarn workspace @model-ts/eventbridge test
 
@@ -74,6 +77,9 @@ jobs:
 
       - name: Install Dependencies
         run: yarn install --frozen-lockfile
+
+      - name: Build Core
+        run: yarn workspace @model-ts/core build
 
       - name: Test
         run: yarn workspace @model-ts/dynamodb test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,18 +11,19 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@master
+        uses: actions/checkout@v4
 
-      - name: Setup Node.js 12.x
-        uses: actions/setup-node@master
+      - name: Setup Node.js 20.x
+        uses: actions/setup-node@v4
         with:
-          node-version: 12.x
+          node-version: 20.x
+          cache: yarn
 
       - name: Install Dependencies
-        run: yarn
+        run: yarn install --frozen-lockfile
 
       - name: Publish to npm
-        uses: changesets/action@master
+        uses: changesets/action@v1
         with:
           publish: yarn release
         env:

--- a/package.json
+++ b/package.json
@@ -4,6 +4,9 @@
   "author": "Fabian Finke <finkef@icloud.com>",
   "license": "MIT",
   "private": true,
+  "engines": {
+    "node": ">=20"
+  },
   "workspaces": [
     "packages/*"
   ],
@@ -17,9 +20,12 @@
   },
   "dependencies": {},
   "devDependencies": {
+    "@aws-sdk/client-dynamodb": "^3.0.0",
+    "@aws-sdk/client-eventbridge": "^3.0.0",
+    "@aws-sdk/lib-dynamodb": "^3.0.0",
     "@changesets/cli": "^2.16.0",
-    "@types/jest": "^27.4.0",
-    "aws-sdk": "^2.691.0",
+    "@types/jest": "^29.5.0",
+    "@types/node": "20.11.0",
     "fp-ts": "^2.6.7",
     "io-ts": "^2.2.16",
     "typescript": "~4.5.5"

--- a/packages/core/jest.config.js
+++ b/packages/core/jest.config.js
@@ -3,9 +3,4 @@ module.exports = {
   transform: {
     "^.+\\.ts$": "ts-jest",
   },
-  globals: {
-    "ts-jest": {
-      isolatedModules: true,
-    },
-  },
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -15,9 +15,9 @@
   },
   "keywords": [],
   "devDependencies": {
-    "@types/jest": "^26.0.24",
-    "jest": "^27.0.4",
-    "ts-jest": "^27.0.3",
+    "@types/jest": "^29.5.0",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.2.5",
     "tslib": "^2.3.0",
     "typescript": "~4.5.5"
   },

--- a/packages/core/src/__test__/model.test.ts
+++ b/packages/core/src/__test__/model.test.ts
@@ -20,7 +20,7 @@ describe("without providers", () => {
       const decoded = MyModel.from({ foo: 42, bar: "omitted" })
       expect(decoded).toBeInstanceOf(MyModel)
       expect(decoded).toMatchInlineSnapshot(`
-        Object {
+        {
           "_tag": "MyModel",
           "foo": 42,
         }
@@ -43,7 +43,7 @@ describe("without providers", () => {
       const decoded = new MyModel({ foo: 42 })
       expect(decoded).toBeInstanceOf(MyModel)
       expect(decoded).toMatchInlineSnapshot(`
-        Object {
+        {
           "_tag": "MyModel",
           "foo": 42,
         }
@@ -111,7 +111,7 @@ describe("with provider", () => {
       const decoded = MyModel.from({ foo: 42, bar: "omitted" })
       expect(decoded).toBeInstanceOf(MyModel)
       expect(decoded).toMatchInlineSnapshot(`
-        Object {
+        {
           "_tag": "MyModel",
           "foo": 42,
         }
@@ -141,7 +141,7 @@ describe("with provider", () => {
       expect(decoded._tag).toEqual(MyModel._tag)
 
       expect(decoded).toMatchInlineSnapshot(`
-        Object {
+        {
           "_tag": "MyModel",
           "foo": 42,
         }
@@ -177,10 +177,10 @@ describe("with provider", () => {
     })
   })
 
-  describe("values", () => {
+  test("it returns values", () => {
     expect(new MyModel({ foo: 432, bar: "omitted" } as any).values())
       .toMatchInlineSnapshot(`
-      Object {
+      {
         "foo": 432,
       }
     `)
@@ -193,10 +193,10 @@ describe("as io-ts codec", () => {
   test("it decodes", () => {
     expect(t.type({ model: MyModel }).decode({ model: { foo: 42 } }))
       .toMatchInlineSnapshot(`
-      Object {
+      {
         "_tag": "Right",
-        "right": Object {
-          "model": Object {
+        "right": {
+          "model": {
             "_tag": "MyModel",
             "foo": 42,
           },
@@ -208,13 +208,13 @@ describe("as io-ts codec", () => {
   test("it fails", () => {
     expect(t.type({ model: MyModel }).decode({ model: "something else" }))
       .toMatchInlineSnapshot(`
-      Object {
+      {
         "_tag": "Left",
-        "left": Array [
-          Object {
-            "context": Array [
-              Object {
-                "actual": Object {
+        "left": [
+          {
+            "context": [
+              {
+                "actual": {
                   "model": "something else",
                 },
                 "key": "",
@@ -224,13 +224,13 @@ describe("as io-ts codec", () => {
                   "encode": [Function],
                   "is": [Function],
                   "name": "{ model: MyModel }",
-                  "props": Object {
+                  "props": {
                     "model": [Function],
                   },
                   "validate": [Function],
                 },
               },
-              Object {
+              {
                 "actual": "something else",
                 "key": "model",
                 "type": [Function],

--- a/packages/core/src/__test__/union.test.ts
+++ b/packages/core/src/__test__/union.test.ts
@@ -18,7 +18,7 @@ describe("without providers", () => {
       const decodedA = Union.from({ a: "a" })
       expect(decodedA).toBeInstanceOf(A)
       expect(decodedA).toMatchInlineSnapshot(`
-        Object {
+        {
           "_tag": "A",
           "a": "a",
         }
@@ -27,7 +27,7 @@ describe("without providers", () => {
       const decodedB = Union.from({ b: 42, c: "" })
       expect(decodedB).toBeInstanceOf(B)
       expect(decodedB).toMatchInlineSnapshot(`
-        Object {
+        {
           "_tag": "B",
           "b": 42,
         }
@@ -50,7 +50,7 @@ describe("without providers", () => {
       const decodedA = Union.from({ _tag: "A", a: "a" })
       expect(decodedA).toBeInstanceOf(A)
       expect(decodedA).toMatchInlineSnapshot(`
-        Object {
+        {
           "_tag": "A",
           "a": "a",
         }
@@ -59,7 +59,7 @@ describe("without providers", () => {
       const decodedB = Union.from({ _tag: "B", b: 42, c: "" })
       expect(decodedB).toBeInstanceOf(B)
       expect(decodedB).toMatchInlineSnapshot(`
-        Object {
+        {
           "_tag": "B",
           "b": 42,
         }
@@ -115,10 +115,10 @@ describe("as io-ts codec", () => {
   test("it decodes", () => {
     expect(t.type({ union: Union }).decode({ union: { b: 42 } }))
       .toMatchInlineSnapshot(`
-      Object {
+      {
         "_tag": "Right",
-        "right": Object {
-          "union": Object {
+        "right": {
+          "union": {
             "_tag": "B",
             "b": 42,
           },
@@ -130,13 +130,13 @@ describe("as io-ts codec", () => {
   test("it fails", () => {
     expect(t.type({ union: Union }).decode({ union: "something else" }))
       .toMatchInlineSnapshot(`
-      Object {
+      {
         "_tag": "Left",
-        "left": Array [
-          Object {
-            "context": Array [
-              Object {
-                "actual": Object {
+        "left": [
+          {
+            "context": [
+              {
+                "actual": {
                   "union": "something else",
                 },
                 "key": "",
@@ -146,18 +146,18 @@ describe("as io-ts codec", () => {
                   "encode": [Function],
                   "is": [Function],
                   "name": "{ union: Union }",
-                  "props": Object {
+                  "props": {
                     "union": [Function],
                   },
                   "validate": [Function],
                 },
               },
-              Object {
+              {
                 "actual": "something else",
                 "key": "union",
                 "type": [Function],
               },
-              Object {
+              {
                 "actual": "something else",
                 "key": "0",
                 "type": [Function],
@@ -166,10 +166,10 @@ describe("as io-ts codec", () => {
             "message": undefined,
             "value": "something else",
           },
-          Object {
-            "context": Array [
-              Object {
-                "actual": Object {
+          {
+            "context": [
+              {
+                "actual": {
                   "union": "something else",
                 },
                 "key": "",
@@ -179,18 +179,18 @@ describe("as io-ts codec", () => {
                   "encode": [Function],
                   "is": [Function],
                   "name": "{ union: Union }",
-                  "props": Object {
+                  "props": {
                     "union": [Function],
                   },
                   "validate": [Function],
                 },
               },
-              Object {
+              {
                 "actual": "something else",
                 "key": "union",
                 "type": [Function],
               },
-              Object {
+              {
                 "actual": "something else",
                 "key": "1",
                 "type": [Function],

--- a/packages/dynamodb/README.md
+++ b/packages/dynamodb/README.md
@@ -1,6 +1,6 @@
 # @model-ts/dynamodb
 
-> model-ts Provider for AWS DynamoDB.
+> model-ts Provider for AWS DynamoDB using AWS SDK for JavaScript v3.
 
 - [Installation](#installation)
 - [Usage](#usage)
@@ -24,7 +24,8 @@ npm install io-ts fp-ts @model-ts/core @model-ts/dynamodb
 yarn add io-ts fp-ts @model-ts/core @model-ts/dynamodb
 ```
 
-Also make sure that you have `aws-sdk` installed.
+This package uses AWS SDK for JavaScript v3. Make sure that you have
+`@aws-sdk/client-dynamodb` and `@aws-sdk/lib-dynamodb` installed.
 
 ## Usage
 

--- a/packages/dynamodb/jest.config.js
+++ b/packages/dynamodb/jest.config.js
@@ -2,12 +2,18 @@ module.exports = {
   preset: "ts-jest",
   testMatch: ["**/*.test.ts"],
   transform: {
-    "^.+\\.ts$": "ts-jest",
+    "^.+\\.[tj]s$": [
+      "ts-jest",
+      {
+        tsconfig: {
+          allowJs: true,
+        },
+      },
+    ],
   },
+  transformIgnorePatterns: [
+    "/node_modules/(?!(@aws-sdk|@smithy)/)",
+    "packages/core/dist/",
+  ],
   setupFilesAfterEnv: ["./src/test-utils/setup.ts"],
-  globals: {
-    "ts-jest": {
-      isolatedModules: true,
-    },
-  },
 }

--- a/packages/dynamodb/package.json
+++ b/packages/dynamodb/package.json
@@ -5,6 +5,9 @@
   "module": "dist/esm/index.js",
   "author": "Fabian Finke <finkef@icloud.com>",
   "license": "MIT",
+  "engines": {
+    "node": ">=20"
+  },
   "scripts": {
     "build": "tsc -b",
     "build:esm": "tsc -b tsconfig.esm.json",
@@ -16,17 +19,19 @@
   "keywords": [],
   "peerDependencies": {
     "@model-ts/core": "^0.4.2",
-    "aws-sdk": "^2.691.0"
+    "@aws-sdk/client-dynamodb": "^3.0.0",
+    "@aws-sdk/lib-dynamodb": "^3.0.0"
   },
   "devDependencies": {
+    "@aws-sdk/client-dynamodb": "^3.0.0",
+    "@aws-sdk/lib-dynamodb": "^3.0.0",
     "@model-ts/core": "*",
-    "@types/jest": "^26.0.24",
-    "aws-sdk": "^2.691.0",
+    "@types/jest": "^29.5.0",
     "io-ts": "^2.2.4",
-    "jest": "^27.0.4",
+    "jest": "^29.7.0",
     "mockdate": "^3.0.5",
     "prettier": "^2.2.1",
-    "ts-jest": "^27.0.3",
+    "ts-jest": "^29.2.5",
     "tslib": "^2.3.0",
     "typescript": "~4.5.5"
   },

--- a/packages/dynamodb/src/__test__/client-with-cursor-encryption.test.ts
+++ b/packages/dynamodb/src/__test__/client-with-cursor-encryption.test.ts
@@ -158,14 +158,14 @@ describe("put", () => {
       await new Simple({ foo: "hi", bar: 42 }).put()
 
       expect(await sandbox.diff(before)).toMatchInlineSnapshot(`
-+ [PK#hi / SK#42]
-+   PK: "PK#hi"
-+   SK: "SK#42"
-+   _docVersion: 0
-+   _tag: "Simple"
-+   bar: 42
-+   foo: "hi"
-`)
+        + [PK#hi / SK#42]
+        +   PK: "PK#hi"
+        +   SK: "SK#42"
+        +   _docVersion: 0
+        +   _tag: "Simple"
+        +   bar: 42
+        +   foo: "hi"
+      `)
     })
 
     test("it inserts a model with single gsi", async () => {
@@ -174,16 +174,16 @@ describe("put", () => {
       await new SingleGSI({ foo: "yes", bar: 42 }).put()
 
       expect(await sandbox.diff(before)).toMatchInlineSnapshot(`
-+ [PK#yes / SK#42]
-+   PK: "PK#yes"
-+   SK: "SK#42"
-+   GSI2PK: "GSI2PK#yesyes"
-+   GSI2SK: "GSI2SK#FIXED"
-+   _docVersion: 0
-+   _tag: "SingleGSI"
-+   bar: 42
-+   foo: "yes"
-`)
+        + [PK#yes / SK#42]
+        +   PK: "PK#yes"
+        +   SK: "SK#42"
+        +   GSI2PK: "GSI2PK#yesyes"
+        +   GSI2SK: "GSI2SK#FIXED"
+        +   _docVersion: 0
+        +   _tag: "SingleGSI"
+        +   bar: 42
+        +   foo: "yes"
+      `)
     })
 
     test("it inserts a model with multiple gsi", async () => {
@@ -192,24 +192,24 @@ describe("put", () => {
       await new MultiGSI({ foo: "yes", bar: 42 }).put()
 
       expect(await sandbox.diff(before)).toMatchInlineSnapshot(`
-+ [PK#yes / SK#42]
-+   PK: "PK#yes"
-+   SK: "SK#42"
-+   GSI19PK: "GSI19PK#FIXED"
-+   GSI19SK: "GSI19SK#4242"
-+   GSI2PK: "GSI2PK#yesyes"
-+   GSI2SK: "GSI2SK#FIXED"
-+   GSI3PK: "GSI3PK#FIXED"
-+   GSI3SK: "GSI3SK#4242"
-+   GSI4PK: "GSI4PK#FIXED"
-+   GSI4SK: "GSI4SK#4242"
-+   GSI5PK: "GSI5PK#FIXED"
-+   GSI5SK: "GSI5SK#4242"
-+   _docVersion: 0
-+   _tag: "MultiGSI"
-+   bar: 42
-+   foo: "yes"
-`)
+        + [PK#yes / SK#42]
+        +   PK: "PK#yes"
+        +   SK: "SK#42"
+        +   GSI19PK: "GSI19PK#FIXED"
+        +   GSI19SK: "GSI19SK#4242"
+        +   GSI2PK: "GSI2PK#yesyes"
+        +   GSI2SK: "GSI2SK#FIXED"
+        +   GSI3PK: "GSI3PK#FIXED"
+        +   GSI3SK: "GSI3SK#4242"
+        +   GSI4PK: "GSI4PK#FIXED"
+        +   GSI4SK: "GSI4SK#4242"
+        +   GSI5PK: "GSI5PK#FIXED"
+        +   GSI5SK: "GSI5SK#4242"
+        +   _docVersion: 0
+        +   _tag: "MultiGSI"
+        +   bar: 42
+        +   foo: "yes"
+      `)
     })
 
     test("it throws KeyExistsError if item exists", async () => {
@@ -236,14 +236,14 @@ describe("put", () => {
       await Simple.put(new Simple({ foo: "hi", bar: 42 }))
 
       expect(await sandbox.diff(before)).toMatchInlineSnapshot(`
-+ [PK#hi / SK#42]
-+   PK: "PK#hi"
-+   SK: "SK#42"
-+   _docVersion: 0
-+   _tag: "Simple"
-+   bar: 42
-+   foo: "hi"
-`)
+        + [PK#hi / SK#42]
+        +   PK: "PK#hi"
+        +   SK: "SK#42"
+        +   _docVersion: 0
+        +   _tag: "Simple"
+        +   bar: 42
+        +   foo: "hi"
+      `)
     })
 
     test("it inserts a model with single gsi", async () => {
@@ -252,16 +252,16 @@ describe("put", () => {
       await SingleGSI.put(new SingleGSI({ foo: "yes", bar: 42 }))
 
       expect(await sandbox.diff(before)).toMatchInlineSnapshot(`
-+ [PK#yes / SK#42]
-+   PK: "PK#yes"
-+   SK: "SK#42"
-+   GSI2PK: "GSI2PK#yesyes"
-+   GSI2SK: "GSI2SK#FIXED"
-+   _docVersion: 0
-+   _tag: "SingleGSI"
-+   bar: 42
-+   foo: "yes"
-`)
+        + [PK#yes / SK#42]
+        +   PK: "PK#yes"
+        +   SK: "SK#42"
+        +   GSI2PK: "GSI2PK#yesyes"
+        +   GSI2SK: "GSI2SK#FIXED"
+        +   _docVersion: 0
+        +   _tag: "SingleGSI"
+        +   bar: 42
+        +   foo: "yes"
+      `)
     })
 
     test("it inserts a model with multiple gsi", async () => {
@@ -270,24 +270,24 @@ describe("put", () => {
       await MultiGSI.put(new MultiGSI({ foo: "yes", bar: 42 }))
 
       expect(await sandbox.diff(before)).toMatchInlineSnapshot(`
-+ [PK#yes / SK#42]
-+   PK: "PK#yes"
-+   SK: "SK#42"
-+   GSI19PK: "GSI19PK#FIXED"
-+   GSI19SK: "GSI19SK#4242"
-+   GSI2PK: "GSI2PK#yesyes"
-+   GSI2SK: "GSI2SK#FIXED"
-+   GSI3PK: "GSI3PK#FIXED"
-+   GSI3SK: "GSI3SK#4242"
-+   GSI4PK: "GSI4PK#FIXED"
-+   GSI4SK: "GSI4SK#4242"
-+   GSI5PK: "GSI5PK#FIXED"
-+   GSI5SK: "GSI5SK#4242"
-+   _docVersion: 0
-+   _tag: "MultiGSI"
-+   bar: 42
-+   foo: "yes"
-`)
+        + [PK#yes / SK#42]
+        +   PK: "PK#yes"
+        +   SK: "SK#42"
+        +   GSI19PK: "GSI19PK#FIXED"
+        +   GSI19SK: "GSI19SK#4242"
+        +   GSI2PK: "GSI2PK#yesyes"
+        +   GSI2SK: "GSI2SK#FIXED"
+        +   GSI3PK: "GSI3PK#FIXED"
+        +   GSI3SK: "GSI3SK#4242"
+        +   GSI4PK: "GSI4PK#FIXED"
+        +   GSI4SK: "GSI4SK#4242"
+        +   GSI5PK: "GSI5PK#FIXED"
+        +   GSI5SK: "GSI5SK#4242"
+        +   _docVersion: 0
+        +   _tag: "MultiGSI"
+        +   bar: 42
+        +   foo: "yes"
+      `)
     })
 
     test("it throws KeyExistsError if item exists", async () => {
@@ -327,11 +327,11 @@ describe("get", () => {
       })
 
       expect(result.values()).toMatchInlineSnapshot(`
-              Object {
-                "bar": 432,
-                "foo": "hi",
-              }
-          `)
+        {
+          "bar": 432,
+          "foo": "hi",
+        }
+      `)
 
       expect(result.encode()).toEqual(item.encode())
     })
@@ -359,7 +359,7 @@ describe("get", () => {
 
       expect(result).toBeInstanceOf(C)
       expect(result.values()).toMatchInlineSnapshot(`
-        Object {
+        {
           "c": "0",
           "pk": "PK#0",
           "sk": "SK#0",
@@ -396,14 +396,14 @@ describe("delete", () => {
       expect(result).toBeNull()
 
       expect(await sandbox.diff(before)).toMatchInlineSnapshot(`
-- [PK#hi / SK#432]
--   PK: "PK#hi"
--   SK: "SK#432"
--   _docVersion: 0
--   _tag: "Simple"
--   bar: 432
--   foo: "hi"
-`)
+        - [PK#hi / SK#432]
+        -   PK: "PK#hi"
+        -   SK: "SK#432"
+        -   _docVersion: 0
+        -   _tag: "Simple"
+        -   bar: 432
+        -   foo: "hi"
+      `)
     })
   })
 
@@ -421,14 +421,14 @@ describe("delete", () => {
       expect(result).toBeNull()
 
       expect(await sandbox.diff(before)).toMatchInlineSnapshot(`
-- [PK#hi / SK#432]
--   PK: "PK#hi"
--   SK: "SK#432"
--   _docVersion: 0
--   _tag: "Simple"
--   bar: 432
--   foo: "hi"
-`)
+        - [PK#hi / SK#432]
+        -   PK: "PK#hi"
+        -   SK: "SK#432"
+        -   _docVersion: 0
+        -   _tag: "Simple"
+        -   bar: 432
+        -   foo: "hi"
+      `)
     })
   })
 
@@ -443,14 +443,14 @@ describe("delete", () => {
       expect(result).toBeNull()
 
       expect(await sandbox.diff(before)).toMatchInlineSnapshot(`
-- [PK#hi / SK#432]
--   PK: "PK#hi"
--   SK: "SK#432"
--   _docVersion: 0
--   _tag: "Simple"
--   bar: 432
--   foo: "hi"
-`)
+        - [PK#hi / SK#432]
+        -   PK: "PK#hi"
+        -   SK: "SK#432"
+        -   _docVersion: 0
+        -   _tag: "Simple"
+        -   bar: 432
+        -   foo: "hi"
+      `)
     })
   })
 })
@@ -467,73 +467,73 @@ describe("softDelete", () => {
       const withGSIResult = await client.softDelete(withGSI)
 
       expect(simpleResult.values()).toMatchInlineSnapshot(`
-        Object {
+        {
           "bar": 432,
           "foo": "hi",
         }
       `)
       expect(withGSIResult.values()).toMatchInlineSnapshot(`
-        Object {
+        {
           "bar": 42,
           "foo": "hello",
         }
       `)
 
       expect(await sandbox.diff(before)).toMatchInlineSnapshot(`
-+ [$$DELETED$$PK#hello / $$DELETED$$SK#42]
-+   PK: "$$DELETED$$PK#hello"
-+   SK: "$$DELETED$$SK#42"
-+   GSI19PK: "$$DELETED$$GSI19PK#FIXED"
-+   GSI19SK: "$$DELETED$$GSI19SK#4242"
-+   GSI2PK: "$$DELETED$$GSI2PK#hellohello"
-+   GSI2SK: "$$DELETED$$GSI2SK#FIXED"
-+   GSI3PK: "$$DELETED$$GSI3PK#FIXED"
-+   GSI3SK: "$$DELETED$$GSI3SK#4242"
-+   GSI4PK: "$$DELETED$$GSI4PK#FIXED"
-+   GSI4SK: "$$DELETED$$GSI4SK#4242"
-+   GSI5PK: "$$DELETED$$GSI5PK#FIXED"
-+   GSI5SK: "$$DELETED$$GSI5SK#4242"
-+   _deletedAt: "2021-05-01T08:00:00.000Z"
-+   _docVersion: 0
-+   _tag: "MultiGSI"
-+   bar: 42
-+   foo: "hello"
+        + [$$DELETED$$PK#hello / $$DELETED$$SK#42]
+        +   PK: "$$DELETED$$PK#hello"
+        +   SK: "$$DELETED$$SK#42"
+        +   GSI19PK: "$$DELETED$$GSI19PK#FIXED"
+        +   GSI19SK: "$$DELETED$$GSI19SK#4242"
+        +   GSI2PK: "$$DELETED$$GSI2PK#hellohello"
+        +   GSI2SK: "$$DELETED$$GSI2SK#FIXED"
+        +   GSI3PK: "$$DELETED$$GSI3PK#FIXED"
+        +   GSI3SK: "$$DELETED$$GSI3SK#4242"
+        +   GSI4PK: "$$DELETED$$GSI4PK#FIXED"
+        +   GSI4SK: "$$DELETED$$GSI4SK#4242"
+        +   GSI5PK: "$$DELETED$$GSI5PK#FIXED"
+        +   GSI5SK: "$$DELETED$$GSI5SK#4242"
+        +   _deletedAt: "2021-05-01T08:00:00.000Z"
+        +   _docVersion: 0
+        +   _tag: "MultiGSI"
+        +   bar: 42
+        +   foo: "hello"
 
-+ [$$DELETED$$PK#hi / $$DELETED$$SK#432]
-+   PK: "$$DELETED$$PK#hi"
-+   SK: "$$DELETED$$SK#432"
-+   _deletedAt: "2021-05-01T08:00:00.000Z"
-+   _docVersion: 0
-+   _tag: "Simple"
-+   bar: 432
-+   foo: "hi"
+        + [$$DELETED$$PK#hi / $$DELETED$$SK#432]
+        +   PK: "$$DELETED$$PK#hi"
+        +   SK: "$$DELETED$$SK#432"
+        +   _deletedAt: "2021-05-01T08:00:00.000Z"
+        +   _docVersion: 0
+        +   _tag: "Simple"
+        +   bar: 432
+        +   foo: "hi"
 
-- [PK#hello / SK#42]
--   PK: "PK#hello"
--   SK: "SK#42"
--   GSI19PK: "GSI19PK#FIXED"
--   GSI19SK: "GSI19SK#4242"
--   GSI2PK: "GSI2PK#hellohello"
--   GSI2SK: "GSI2SK#FIXED"
--   GSI3PK: "GSI3PK#FIXED"
--   GSI3SK: "GSI3SK#4242"
--   GSI4PK: "GSI4PK#FIXED"
--   GSI4SK: "GSI4SK#4242"
--   GSI5PK: "GSI5PK#FIXED"
--   GSI5SK: "GSI5SK#4242"
--   _docVersion: 0
--   _tag: "MultiGSI"
--   bar: 42
--   foo: "hello"
+        - [PK#hello / SK#42]
+        -   PK: "PK#hello"
+        -   SK: "SK#42"
+        -   GSI19PK: "GSI19PK#FIXED"
+        -   GSI19SK: "GSI19SK#4242"
+        -   GSI2PK: "GSI2PK#hellohello"
+        -   GSI2SK: "GSI2SK#FIXED"
+        -   GSI3PK: "GSI3PK#FIXED"
+        -   GSI3SK: "GSI3SK#4242"
+        -   GSI4PK: "GSI4PK#FIXED"
+        -   GSI4SK: "GSI4SK#4242"
+        -   GSI5PK: "GSI5PK#FIXED"
+        -   GSI5SK: "GSI5SK#4242"
+        -   _docVersion: 0
+        -   _tag: "MultiGSI"
+        -   bar: 42
+        -   foo: "hello"
 
-- [PK#hi / SK#432]
--   PK: "PK#hi"
--   SK: "SK#432"
--   _docVersion: 0
--   _tag: "Simple"
--   bar: 432
--   foo: "hi"
-`)
+        - [PK#hi / SK#432]
+        -   PK: "PK#hi"
+        -   SK: "SK#432"
+        -   _docVersion: 0
+        -   _tag: "Simple"
+        -   bar: 432
+        -   foo: "hi"
+      `)
     })
   })
 
@@ -546,30 +546,30 @@ describe("softDelete", () => {
       const result = await Simple.softDelete(item)
 
       expect(result.values()).toMatchInlineSnapshot(`
-        Object {
+        {
           "bar": 432,
           "foo": "hi",
         }
       `)
 
       expect(await sandbox.diff(before)).toMatchInlineSnapshot(`
-+ [$$DELETED$$PK#hi / $$DELETED$$SK#432]
-+   PK: "$$DELETED$$PK#hi"
-+   SK: "$$DELETED$$SK#432"
-+   _deletedAt: "2021-05-01T08:00:00.000Z"
-+   _docVersion: 0
-+   _tag: "Simple"
-+   bar: 432
-+   foo: "hi"
+        + [$$DELETED$$PK#hi / $$DELETED$$SK#432]
+        +   PK: "$$DELETED$$PK#hi"
+        +   SK: "$$DELETED$$SK#432"
+        +   _deletedAt: "2021-05-01T08:00:00.000Z"
+        +   _docVersion: 0
+        +   _tag: "Simple"
+        +   bar: 432
+        +   foo: "hi"
 
-- [PK#hi / SK#432]
--   PK: "PK#hi"
--   SK: "SK#432"
--   _docVersion: 0
--   _tag: "Simple"
--   bar: 432
--   foo: "hi"
-`)
+        - [PK#hi / SK#432]
+        -   PK: "PK#hi"
+        -   SK: "SK#432"
+        -   _docVersion: 0
+        -   _tag: "Simple"
+        -   bar: 432
+        -   foo: "hi"
+      `)
     })
   })
 
@@ -582,30 +582,30 @@ describe("softDelete", () => {
       const result = await item.softDelete()
 
       expect(result.values()).toMatchInlineSnapshot(`
-        Object {
+        {
           "bar": 432,
           "foo": "hi",
         }
       `)
 
       expect(await sandbox.diff(before)).toMatchInlineSnapshot(`
-+ [$$DELETED$$PK#hi / $$DELETED$$SK#432]
-+   PK: "$$DELETED$$PK#hi"
-+   SK: "$$DELETED$$SK#432"
-+   _deletedAt: "2021-05-01T08:00:00.000Z"
-+   _docVersion: 0
-+   _tag: "Simple"
-+   bar: 432
-+   foo: "hi"
+        + [$$DELETED$$PK#hi / $$DELETED$$SK#432]
+        +   PK: "$$DELETED$$PK#hi"
+        +   SK: "$$DELETED$$SK#432"
+        +   _deletedAt: "2021-05-01T08:00:00.000Z"
+        +   _docVersion: 0
+        +   _tag: "Simple"
+        +   bar: 432
+        +   foo: "hi"
 
-- [PK#hi / SK#432]
--   PK: "PK#hi"
--   SK: "SK#432"
--   _docVersion: 0
--   _tag: "Simple"
--   bar: 432
--   foo: "hi"
-`)
+        - [PK#hi / SK#432]
+        -   PK: "PK#hi"
+        -   SK: "SK#432"
+        -   _docVersion: 0
+        -   _tag: "Simple"
+        -   bar: 432
+        -   foo: "hi"
+      `)
     })
   })
 })
@@ -639,8 +639,8 @@ describe("updateRaw", () => {
     // that it is not reflected in the DB!
     expect(result.PK).toEqual(`PK#new foo`)
     expect(await sandbox.snapshot()).toMatchInlineSnapshot(`
-      Object {
-        "PK#old__SK#43": Object {
+      {
+        "PK#old__SK#43": {
           "PK": "PK#old",
           "SK": "SK#43",
           "_docVersion": 0,
@@ -675,8 +675,8 @@ describe("update", () => {
       await item.update({ foo: "ciao" })
 
       expect(await sandbox.snapshot()).toMatchInlineSnapshot(`
-        Object {
-          "FIXEDPK__FIXEDSK": Object {
+        {
+          "FIXEDPK__FIXEDSK": {
             "PK": "FIXEDPK",
             "SK": "FIXEDSK",
             "_docVersion": 1,
@@ -704,23 +704,23 @@ describe("update", () => {
 
       expect((await item.update({ foo: "ciao" })).values())
         .toMatchInlineSnapshot(`
-        Object {
+        {
           "bar": 1,
           "foo": "ciao",
         }
       `)
 
       expect(await sandbox.diff(before)).toMatchInlineSnapshot(`
-[FIXEDPK / FIXEDSK]
-    PK: "FIXEDPK"
-    SK: "FIXEDSK"
--   _docVersion: 0
-+   _docVersion: 1
-    _tag: "InPlace"
-    bar: 1
--   foo: "hello"
-+   foo: "ciao"
-`)
+        [FIXEDPK / FIXEDSK]
+            PK: "FIXEDPK"
+            SK: "FIXEDSK"
+        -   _docVersion: 0
+        +   _docVersion: 1
+            _tag: "InPlace"
+            bar: 1
+        -   foo: "hello"
+        +   foo: "ciao"
+      `)
     })
   })
 })
@@ -733,7 +733,7 @@ describe("applyUpdate", () => {
 
     const [updatedItem, updateOp] = item.applyUpdate({ a: 2 })
     expect(updatedItem.values()).toMatchInlineSnapshot(`
-      Object {
+      {
         "a": 2,
         "pk": "PK",
         "sk": "SK",
@@ -743,17 +743,17 @@ describe("applyUpdate", () => {
     await client.bulk([updateOp])
 
     expect(await sandbox.diff(before)).toMatchInlineSnapshot(`
-[PK / SK]
-    PK: "PK"
-    SK: "SK"
--   _docVersion: 0
-+   _docVersion: 1
-    _tag: "A"
--   a: 1
-+   a: 2
-    pk: "PK"
-    sk: "SK"
-`)
+      [PK / SK]
+          PK: "PK"
+          SK: "SK"
+      -   _docVersion: 0
+      +   _docVersion: 1
+          _tag: "A"
+      -   a: 1
+      +   a: 2
+          pk: "PK"
+          sk: "SK"
+    `)
   })
 })
 
@@ -765,17 +765,18 @@ describe("query", () => {
           KeyConditionExpression: `PK = :pk and begins_with(SK, :sk)`,
           ExpressionAttributeValues: { ":pk": "abc", ":sk": "SORT" }
         },
+
         { a: A, b: B, union: Union }
       )
     ).toMatchInlineSnapshot(`
-      Object {
-        "_unknown": Array [],
-        "a": Array [],
-        "b": Array [],
-        "meta": Object {
+      {
+        "_unknown": [],
+        "a": [],
+        "b": [],
+        "meta": {
           "lastEvaluatedKey": undefined,
         },
-        "union": Array [],
+        "union": [],
       }
     `)
   })
@@ -789,23 +790,24 @@ describe("query", () => {
           KeyConditionExpression: `PK = :pk and begins_with(SK, :sk)`,
           ExpressionAttributeValues: { ":pk": "abc", ":sk": "SORT#" }
         },
+
         { a: A, b: B, union: Union }
       )
     ).toMatchInlineSnapshot(`
-      Object {
-        "_unknown": Array [
-          Object {
+      {
+        "_unknown": [
+          {
             "PK": "abc",
             "SK": "SORT#1",
             "doesnt": "match",
           },
         ],
-        "a": Array [],
-        "b": Array [],
-        "meta": Object {
+        "a": [],
+        "b": [],
+        "meta": {
           "lastEvaluatedKey": undefined,
         },
-        "union": Array [],
+        "union": [],
       }
     `)
   })
@@ -835,43 +837,43 @@ describe("query", () => {
       b: b.map(item => item.values()),
       union: union.map(item => item.values())
     }).toMatchInlineSnapshot(`
-      Object {
-        "_unknown": Array [
-          Object {
+      {
+        "_unknown": [
+          {
             "PK": "abc",
             "SK": "SORT#4",
             "probably": "unknown",
           },
         ],
-        "a": Array [
-          Object {
+        "a": [
+          {
             "a": 1,
             "pk": "abc",
             "sk": "SORT#1",
           },
-          Object {
+          {
             "a": 2,
             "pk": "abc",
             "sk": "SORT#2",
           },
         ],
-        "b": Array [
-          Object {
+        "b": [
+          {
             "b": "hi",
             "pk": "abc",
             "sk": "SORT#3",
           },
         ],
-        "meta": Object {
+        "meta": {
           "lastEvaluatedKey": undefined,
         },
-        "union": Array [
-          Object {
+        "union": [
+          {
             "c": "hi",
             "pk": "abc",
             "sk": "SORT#5",
           },
-          Object {
+          {
             "d": "hi",
             "pk": "abc",
             "sk": "SORT#6",
@@ -989,82 +991,82 @@ describe("bulk", () => {
       ])
 
       expect(await sandbox.diff(before)).toMatchInlineSnapshot(`
-+ [$$DELETED$$PK#3 / $$DELETED$$SK#3]
-+   PK: "$$DELETED$$PK#3"
-+   SK: "$$DELETED$$SK#3"
-+   _deletedAt: "2021-05-01T08:00:00.000Z"
-+   _docVersion: 0
-+   _tag: "B"
-+   b: "bar"
-+   pk: "PK#3"
-+   sk: "SK#3"
+        + [$$DELETED$$PK#3 / $$DELETED$$SK#3]
+        +   PK: "$$DELETED$$PK#3"
+        +   SK: "$$DELETED$$SK#3"
+        +   _deletedAt: "2021-05-01T08:00:00.000Z"
+        +   _docVersion: 0
+        +   _tag: "B"
+        +   b: "bar"
+        +   pk: "PK#3"
+        +   sk: "SK#3"
 
-[PK#1 / SK#1]
-    PK: "PK#1"
-    SK: "SK#1"
-    _docVersion: 0
-    _tag: "A"
--   a: 1
-+   a: -1
-    pk: "PK#1"
-    sk: "SK#1"
+        [PK#1 / SK#1]
+            PK: "PK#1"
+            SK: "SK#1"
+            _docVersion: 0
+            _tag: "A"
+        -   a: 1
+        +   a: -1
+            pk: "PK#1"
+            sk: "SK#1"
 
-- [PK#2 / SK#2]
--   PK: "PK#2"
--   SK: "SK#2"
--   _docVersion: 0
--   _tag: "A"
--   a: 2
--   pk: "PK#2"
--   sk: "SK#2"
+        - [PK#2 / SK#2]
+        -   PK: "PK#2"
+        -   SK: "SK#2"
+        -   _docVersion: 0
+        -   _tag: "A"
+        -   a: 2
+        -   pk: "PK#2"
+        -   sk: "SK#2"
 
-- [PK#3 / SK#3]
--   PK: "PK#3"
--   SK: "SK#3"
--   _docVersion: 0
--   _tag: "B"
--   b: "bar"
--   pk: "PK#3"
--   sk: "SK#3"
+        - [PK#3 / SK#3]
+        -   PK: "PK#3"
+        -   SK: "SK#3"
+        -   _docVersion: 0
+        -   _tag: "B"
+        -   b: "bar"
+        -   pk: "PK#3"
+        -   sk: "SK#3"
 
-[PK#UPDATE / SK#UPDATE]
-    PK: "PK#UPDATE"
-    SK: "SK#UPDATE"
--   _docVersion: 0
-+   _docVersion: 1
-    _tag: "B"
--   b: "bar"
-+   b: "baz"
-    pk: "PK#UPDATE"
-    sk: "SK#UPDATE"
+        [PK#UPDATE / SK#UPDATE]
+            PK: "PK#UPDATE"
+            SK: "SK#UPDATE"
+        -   _docVersion: 0
+        +   _docVersion: 1
+            _tag: "B"
+        -   b: "bar"
+        +   b: "baz"
+            pk: "PK#UPDATE"
+            sk: "SK#UPDATE"
 
-+ [PK4 / PK4]
-+   PK: "PK4"
-+   SK: "PK4"
-+   _docVersion: 0
-+   _tag: "A"
-+   a: 4
-+   pk: "PK4"
-+   sk: "PK4"
+        + [PK4 / PK4]
+        +   PK: "PK4"
+        +   SK: "PK4"
+        +   _docVersion: 0
+        +   _tag: "A"
+        +   a: 4
+        +   pk: "PK4"
+        +   sk: "PK4"
 
-+ [PK5 / PK5]
-+   PK: "PK5"
-+   SK: "PK5"
-+   _docVersion: 0
-+   _tag: "A"
-+   a: 5
-+   pk: "PK5"
-+   sk: "PK5"
+        + [PK5 / PK5]
+        +   PK: "PK5"
+        +   SK: "PK5"
+        +   _docVersion: 0
+        +   _tag: "A"
+        +   a: 5
+        +   pk: "PK5"
+        +   sk: "PK5"
 
-+ [PK6 / SK6]
-+   PK: "PK6"
-+   SK: "SK6"
-+   _docVersion: 0
-+   _tag: "B"
-+   b: "baz"
-+   pk: "PK6"
-+   sk: "SK6"
-`)
+        + [PK6 / SK6]
+        +   PK: "PK6"
+        +   SK: "SK6"
+        +   _docVersion: 0
+        +   _tag: "B"
+        +   b: "baz"
+        +   pk: "PK6"
+        +   sk: "SK6"
+      `)
     })
 
     test("it fails", async () => {
@@ -1127,970 +1129,970 @@ describe("bulk", () => {
 
       //#region snapshot
       expect(await sandbox.diff(before)).toMatchInlineSnapshot(`
-[PK#1 / SK#1]
-    PK: "PK#1"
-    SK: "SK#1"
-    _docVersion: 0
-    _tag: "A"
--   a: 1
-+   a: -1
-    pk: "PK#1"
-    sk: "SK#1"
-
-- [PK#2 / SK#2]
--   PK: "PK#2"
--   SK: "SK#2"
--   _docVersion: 0
--   _tag: "A"
--   a: 2
--   pk: "PK#2"
--   sk: "SK#2"
-
-- [PK#3 / SK#3]
--   PK: "PK#3"
--   SK: "SK#3"
--   _docVersion: 0
--   _tag: "B"
--   b: "bar"
--   pk: "PK#3"
--   sk: "SK#3"
-
-+ [PK#A0 / SK#A0]
-+   PK: "PK#A0"
-+   SK: "SK#A0"
-+   _docVersion: 0
-+   _tag: "A"
-+   a: 0
-+   pk: "PK#A0"
-+   sk: "SK#A0"
-
-+ [PK#A1 / SK#A1]
-+   PK: "PK#A1"
-+   SK: "SK#A1"
-+   _docVersion: 0
-+   _tag: "A"
-+   a: 1
-+   pk: "PK#A1"
-+   sk: "SK#A1"
-
-+ [PK#A10 / SK#A10]
-+   PK: "PK#A10"
-+   SK: "SK#A10"
-+   _docVersion: 0
-+   _tag: "A"
-+   a: 10
-+   pk: "PK#A10"
-+   sk: "SK#A10"
-
-+ [PK#A11 / SK#A11]
-+   PK: "PK#A11"
-+   SK: "SK#A11"
-+   _docVersion: 0
-+   _tag: "A"
-+   a: 11
-+   pk: "PK#A11"
-+   sk: "SK#A11"
-
-+ [PK#A12 / SK#A12]
-+   PK: "PK#A12"
-+   SK: "SK#A12"
-+   _docVersion: 0
-+   _tag: "A"
-+   a: 12
-+   pk: "PK#A12"
-+   sk: "SK#A12"
-
-+ [PK#A13 / SK#A13]
-+   PK: "PK#A13"
-+   SK: "SK#A13"
-+   _docVersion: 0
-+   _tag: "A"
-+   a: 13
-+   pk: "PK#A13"
-+   sk: "SK#A13"
-
-+ [PK#A14 / SK#A14]
-+   PK: "PK#A14"
-+   SK: "SK#A14"
-+   _docVersion: 0
-+   _tag: "A"
-+   a: 14
-+   pk: "PK#A14"
-+   sk: "SK#A14"
-
-+ [PK#A15 / SK#A15]
-+   PK: "PK#A15"
-+   SK: "SK#A15"
-+   _docVersion: 0
-+   _tag: "A"
-+   a: 15
-+   pk: "PK#A15"
-+   sk: "SK#A15"
-
-+ [PK#A16 / SK#A16]
-+   PK: "PK#A16"
-+   SK: "SK#A16"
-+   _docVersion: 0
-+   _tag: "A"
-+   a: 16
-+   pk: "PK#A16"
-+   sk: "SK#A16"
-
-+ [PK#A17 / SK#A17]
-+   PK: "PK#A17"
-+   SK: "SK#A17"
-+   _docVersion: 0
-+   _tag: "A"
-+   a: 17
-+   pk: "PK#A17"
-+   sk: "SK#A17"
-
-+ [PK#A18 / SK#A18]
-+   PK: "PK#A18"
-+   SK: "SK#A18"
-+   _docVersion: 0
-+   _tag: "A"
-+   a: 18
-+   pk: "PK#A18"
-+   sk: "SK#A18"
-
-+ [PK#A19 / SK#A19]
-+   PK: "PK#A19"
-+   SK: "SK#A19"
-+   _docVersion: 0
-+   _tag: "A"
-+   a: 19
-+   pk: "PK#A19"
-+   sk: "SK#A19"
-
-+ [PK#A2 / SK#A2]
-+   PK: "PK#A2"
-+   SK: "SK#A2"
-+   _docVersion: 0
-+   _tag: "A"
-+   a: 2
-+   pk: "PK#A2"
-+   sk: "SK#A2"
-
-+ [PK#A20 / SK#A20]
-+   PK: "PK#A20"
-+   SK: "SK#A20"
-+   _docVersion: 0
-+   _tag: "A"
-+   a: 20
-+   pk: "PK#A20"
-+   sk: "SK#A20"
-
-+ [PK#A21 / SK#A21]
-+   PK: "PK#A21"
-+   SK: "SK#A21"
-+   _docVersion: 0
-+   _tag: "A"
-+   a: 21
-+   pk: "PK#A21"
-+   sk: "SK#A21"
-
-+ [PK#A22 / SK#A22]
-+   PK: "PK#A22"
-+   SK: "SK#A22"
-+   _docVersion: 0
-+   _tag: "A"
-+   a: 22
-+   pk: "PK#A22"
-+   sk: "SK#A22"
-
-+ [PK#A23 / SK#A23]
-+   PK: "PK#A23"
-+   SK: "SK#A23"
-+   _docVersion: 0
-+   _tag: "A"
-+   a: 23
-+   pk: "PK#A23"
-+   sk: "SK#A23"
-
-+ [PK#A24 / SK#A24]
-+   PK: "PK#A24"
-+   SK: "SK#A24"
-+   _docVersion: 0
-+   _tag: "A"
-+   a: 24
-+   pk: "PK#A24"
-+   sk: "SK#A24"
-
-+ [PK#A25 / SK#A25]
-+   PK: "PK#A25"
-+   SK: "SK#A25"
-+   _docVersion: 0
-+   _tag: "A"
-+   a: 25
-+   pk: "PK#A25"
-+   sk: "SK#A25"
-
-+ [PK#A26 / SK#A26]
-+   PK: "PK#A26"
-+   SK: "SK#A26"
-+   _docVersion: 0
-+   _tag: "A"
-+   a: 26
-+   pk: "PK#A26"
-+   sk: "SK#A26"
-
-+ [PK#A27 / SK#A27]
-+   PK: "PK#A27"
-+   SK: "SK#A27"
-+   _docVersion: 0
-+   _tag: "A"
-+   a: 27
-+   pk: "PK#A27"
-+   sk: "SK#A27"
-
-+ [PK#A28 / SK#A28]
-+   PK: "PK#A28"
-+   SK: "SK#A28"
-+   _docVersion: 0
-+   _tag: "A"
-+   a: 28
-+   pk: "PK#A28"
-+   sk: "SK#A28"
-
-+ [PK#A29 / SK#A29]
-+   PK: "PK#A29"
-+   SK: "SK#A29"
-+   _docVersion: 0
-+   _tag: "A"
-+   a: 29
-+   pk: "PK#A29"
-+   sk: "SK#A29"
-
-+ [PK#A3 / SK#A3]
-+   PK: "PK#A3"
-+   SK: "SK#A3"
-+   _docVersion: 0
-+   _tag: "A"
-+   a: 3
-+   pk: "PK#A3"
-+   sk: "SK#A3"
-
-+ [PK#A30 / SK#A30]
-+   PK: "PK#A30"
-+   SK: "SK#A30"
-+   _docVersion: 0
-+   _tag: "A"
-+   a: 30
-+   pk: "PK#A30"
-+   sk: "SK#A30"
-
-+ [PK#A31 / SK#A31]
-+   PK: "PK#A31"
-+   SK: "SK#A31"
-+   _docVersion: 0
-+   _tag: "A"
-+   a: 31
-+   pk: "PK#A31"
-+   sk: "SK#A31"
-
-+ [PK#A32 / SK#A32]
-+   PK: "PK#A32"
-+   SK: "SK#A32"
-+   _docVersion: 0
-+   _tag: "A"
-+   a: 32
-+   pk: "PK#A32"
-+   sk: "SK#A32"
-
-+ [PK#A33 / SK#A33]
-+   PK: "PK#A33"
-+   SK: "SK#A33"
-+   _docVersion: 0
-+   _tag: "A"
-+   a: 33
-+   pk: "PK#A33"
-+   sk: "SK#A33"
-
-+ [PK#A34 / SK#A34]
-+   PK: "PK#A34"
-+   SK: "SK#A34"
-+   _docVersion: 0
-+   _tag: "A"
-+   a: 34
-+   pk: "PK#A34"
-+   sk: "SK#A34"
-
-+ [PK#A35 / SK#A35]
-+   PK: "PK#A35"
-+   SK: "SK#A35"
-+   _docVersion: 0
-+   _tag: "A"
-+   a: 35
-+   pk: "PK#A35"
-+   sk: "SK#A35"
-
-+ [PK#A36 / SK#A36]
-+   PK: "PK#A36"
-+   SK: "SK#A36"
-+   _docVersion: 0
-+   _tag: "A"
-+   a: 36
-+   pk: "PK#A36"
-+   sk: "SK#A36"
-
-+ [PK#A37 / SK#A37]
-+   PK: "PK#A37"
-+   SK: "SK#A37"
-+   _docVersion: 0
-+   _tag: "A"
-+   a: 37
-+   pk: "PK#A37"
-+   sk: "SK#A37"
-
-+ [PK#A38 / SK#A38]
-+   PK: "PK#A38"
-+   SK: "SK#A38"
-+   _docVersion: 0
-+   _tag: "A"
-+   a: 38
-+   pk: "PK#A38"
-+   sk: "SK#A38"
-
-+ [PK#A39 / SK#A39]
-+   PK: "PK#A39"
-+   SK: "SK#A39"
-+   _docVersion: 0
-+   _tag: "A"
-+   a: 39
-+   pk: "PK#A39"
-+   sk: "SK#A39"
-
-+ [PK#A4 / SK#A4]
-+   PK: "PK#A4"
-+   SK: "SK#A4"
-+   _docVersion: 0
-+   _tag: "A"
-+   a: 4
-+   pk: "PK#A4"
-+   sk: "SK#A4"
-
-+ [PK#A40 / SK#A40]
-+   PK: "PK#A40"
-+   SK: "SK#A40"
-+   _docVersion: 0
-+   _tag: "A"
-+   a: 40
-+   pk: "PK#A40"
-+   sk: "SK#A40"
-
-+ [PK#A41 / SK#A41]
-+   PK: "PK#A41"
-+   SK: "SK#A41"
-+   _docVersion: 0
-+   _tag: "A"
-+   a: 41
-+   pk: "PK#A41"
-+   sk: "SK#A41"
-
-+ [PK#A42 / SK#A42]
-+   PK: "PK#A42"
-+   SK: "SK#A42"
-+   _docVersion: 0
-+   _tag: "A"
-+   a: 42
-+   pk: "PK#A42"
-+   sk: "SK#A42"
-
-+ [PK#A43 / SK#A43]
-+   PK: "PK#A43"
-+   SK: "SK#A43"
-+   _docVersion: 0
-+   _tag: "A"
-+   a: 43
-+   pk: "PK#A43"
-+   sk: "SK#A43"
-
-+ [PK#A44 / SK#A44]
-+   PK: "PK#A44"
-+   SK: "SK#A44"
-+   _docVersion: 0
-+   _tag: "A"
-+   a: 44
-+   pk: "PK#A44"
-+   sk: "SK#A44"
-
-+ [PK#A45 / SK#A45]
-+   PK: "PK#A45"
-+   SK: "SK#A45"
-+   _docVersion: 0
-+   _tag: "A"
-+   a: 45
-+   pk: "PK#A45"
-+   sk: "SK#A45"
-
-+ [PK#A46 / SK#A46]
-+   PK: "PK#A46"
-+   SK: "SK#A46"
-+   _docVersion: 0
-+   _tag: "A"
-+   a: 46
-+   pk: "PK#A46"
-+   sk: "SK#A46"
-
-+ [PK#A47 / SK#A47]
-+   PK: "PK#A47"
-+   SK: "SK#A47"
-+   _docVersion: 0
-+   _tag: "A"
-+   a: 47
-+   pk: "PK#A47"
-+   sk: "SK#A47"
-
-+ [PK#A48 / SK#A48]
-+   PK: "PK#A48"
-+   SK: "SK#A48"
-+   _docVersion: 0
-+   _tag: "A"
-+   a: 48
-+   pk: "PK#A48"
-+   sk: "SK#A48"
-
-+ [PK#A49 / SK#A49]
-+   PK: "PK#A49"
-+   SK: "SK#A49"
-+   _docVersion: 0
-+   _tag: "A"
-+   a: 49
-+   pk: "PK#A49"
-+   sk: "SK#A49"
-
-+ [PK#A5 / SK#A5]
-+   PK: "PK#A5"
-+   SK: "SK#A5"
-+   _docVersion: 0
-+   _tag: "A"
-+   a: 5
-+   pk: "PK#A5"
-+   sk: "SK#A5"
-
-+ [PK#A50 / SK#A50]
-+   PK: "PK#A50"
-+   SK: "SK#A50"
-+   _docVersion: 0
-+   _tag: "A"
-+   a: 50
-+   pk: "PK#A50"
-+   sk: "SK#A50"
-
-+ [PK#A51 / SK#A51]
-+   PK: "PK#A51"
-+   SK: "SK#A51"
-+   _docVersion: 0
-+   _tag: "A"
-+   a: 51
-+   pk: "PK#A51"
-+   sk: "SK#A51"
-
-+ [PK#A52 / SK#A52]
-+   PK: "PK#A52"
-+   SK: "SK#A52"
-+   _docVersion: 0
-+   _tag: "A"
-+   a: 52
-+   pk: "PK#A52"
-+   sk: "SK#A52"
-
-+ [PK#A53 / SK#A53]
-+   PK: "PK#A53"
-+   SK: "SK#A53"
-+   _docVersion: 0
-+   _tag: "A"
-+   a: 53
-+   pk: "PK#A53"
-+   sk: "SK#A53"
-
-+ [PK#A54 / SK#A54]
-+   PK: "PK#A54"
-+   SK: "SK#A54"
-+   _docVersion: 0
-+   _tag: "A"
-+   a: 54
-+   pk: "PK#A54"
-+   sk: "SK#A54"
-
-+ [PK#A55 / SK#A55]
-+   PK: "PK#A55"
-+   SK: "SK#A55"
-+   _docVersion: 0
-+   _tag: "A"
-+   a: 55
-+   pk: "PK#A55"
-+   sk: "SK#A55"
-
-+ [PK#A56 / SK#A56]
-+   PK: "PK#A56"
-+   SK: "SK#A56"
-+   _docVersion: 0
-+   _tag: "A"
-+   a: 56
-+   pk: "PK#A56"
-+   sk: "SK#A56"
-
-+ [PK#A57 / SK#A57]
-+   PK: "PK#A57"
-+   SK: "SK#A57"
-+   _docVersion: 0
-+   _tag: "A"
-+   a: 57
-+   pk: "PK#A57"
-+   sk: "SK#A57"
-
-+ [PK#A58 / SK#A58]
-+   PK: "PK#A58"
-+   SK: "SK#A58"
-+   _docVersion: 0
-+   _tag: "A"
-+   a: 58
-+   pk: "PK#A58"
-+   sk: "SK#A58"
-
-+ [PK#A59 / SK#A59]
-+   PK: "PK#A59"
-+   SK: "SK#A59"
-+   _docVersion: 0
-+   _tag: "A"
-+   a: 59
-+   pk: "PK#A59"
-+   sk: "SK#A59"
-
-+ [PK#A6 / SK#A6]
-+   PK: "PK#A6"
-+   SK: "SK#A6"
-+   _docVersion: 0
-+   _tag: "A"
-+   a: 6
-+   pk: "PK#A6"
-+   sk: "SK#A6"
-
-+ [PK#A60 / SK#A60]
-+   PK: "PK#A60"
-+   SK: "SK#A60"
-+   _docVersion: 0
-+   _tag: "A"
-+   a: 60
-+   pk: "PK#A60"
-+   sk: "SK#A60"
-
-+ [PK#A61 / SK#A61]
-+   PK: "PK#A61"
-+   SK: "SK#A61"
-+   _docVersion: 0
-+   _tag: "A"
-+   a: 61
-+   pk: "PK#A61"
-+   sk: "SK#A61"
-
-+ [PK#A62 / SK#A62]
-+   PK: "PK#A62"
-+   SK: "SK#A62"
-+   _docVersion: 0
-+   _tag: "A"
-+   a: 62
-+   pk: "PK#A62"
-+   sk: "SK#A62"
-
-+ [PK#A63 / SK#A63]
-+   PK: "PK#A63"
-+   SK: "SK#A63"
-+   _docVersion: 0
-+   _tag: "A"
-+   a: 63
-+   pk: "PK#A63"
-+   sk: "SK#A63"
-
-+ [PK#A64 / SK#A64]
-+   PK: "PK#A64"
-+   SK: "SK#A64"
-+   _docVersion: 0
-+   _tag: "A"
-+   a: 64
-+   pk: "PK#A64"
-+   sk: "SK#A64"
-
-+ [PK#A65 / SK#A65]
-+   PK: "PK#A65"
-+   SK: "SK#A65"
-+   _docVersion: 0
-+   _tag: "A"
-+   a: 65
-+   pk: "PK#A65"
-+   sk: "SK#A65"
-
-+ [PK#A66 / SK#A66]
-+   PK: "PK#A66"
-+   SK: "SK#A66"
-+   _docVersion: 0
-+   _tag: "A"
-+   a: 66
-+   pk: "PK#A66"
-+   sk: "SK#A66"
-
-+ [PK#A67 / SK#A67]
-+   PK: "PK#A67"
-+   SK: "SK#A67"
-+   _docVersion: 0
-+   _tag: "A"
-+   a: 67
-+   pk: "PK#A67"
-+   sk: "SK#A67"
-
-+ [PK#A68 / SK#A68]
-+   PK: "PK#A68"
-+   SK: "SK#A68"
-+   _docVersion: 0
-+   _tag: "A"
-+   a: 68
-+   pk: "PK#A68"
-+   sk: "SK#A68"
-
-+ [PK#A69 / SK#A69]
-+   PK: "PK#A69"
-+   SK: "SK#A69"
-+   _docVersion: 0
-+   _tag: "A"
-+   a: 69
-+   pk: "PK#A69"
-+   sk: "SK#A69"
-
-+ [PK#A7 / SK#A7]
-+   PK: "PK#A7"
-+   SK: "SK#A7"
-+   _docVersion: 0
-+   _tag: "A"
-+   a: 7
-+   pk: "PK#A7"
-+   sk: "SK#A7"
-
-+ [PK#A70 / SK#A70]
-+   PK: "PK#A70"
-+   SK: "SK#A70"
-+   _docVersion: 0
-+   _tag: "A"
-+   a: 70
-+   pk: "PK#A70"
-+   sk: "SK#A70"
-
-+ [PK#A71 / SK#A71]
-+   PK: "PK#A71"
-+   SK: "SK#A71"
-+   _docVersion: 0
-+   _tag: "A"
-+   a: 71
-+   pk: "PK#A71"
-+   sk: "SK#A71"
-
-+ [PK#A72 / SK#A72]
-+   PK: "PK#A72"
-+   SK: "SK#A72"
-+   _docVersion: 0
-+   _tag: "A"
-+   a: 72
-+   pk: "PK#A72"
-+   sk: "SK#A72"
-
-+ [PK#A73 / SK#A73]
-+   PK: "PK#A73"
-+   SK: "SK#A73"
-+   _docVersion: 0
-+   _tag: "A"
-+   a: 73
-+   pk: "PK#A73"
-+   sk: "SK#A73"
-
-+ [PK#A74 / SK#A74]
-+   PK: "PK#A74"
-+   SK: "SK#A74"
-+   _docVersion: 0
-+   _tag: "A"
-+   a: 74
-+   pk: "PK#A74"
-+   sk: "SK#A74"
-
-+ [PK#A75 / SK#A75]
-+   PK: "PK#A75"
-+   SK: "SK#A75"
-+   _docVersion: 0
-+   _tag: "A"
-+   a: 75
-+   pk: "PK#A75"
-+   sk: "SK#A75"
-
-+ [PK#A76 / SK#A76]
-+   PK: "PK#A76"
-+   SK: "SK#A76"
-+   _docVersion: 0
-+   _tag: "A"
-+   a: 76
-+   pk: "PK#A76"
-+   sk: "SK#A76"
-
-+ [PK#A77 / SK#A77]
-+   PK: "PK#A77"
-+   SK: "SK#A77"
-+   _docVersion: 0
-+   _tag: "A"
-+   a: 77
-+   pk: "PK#A77"
-+   sk: "SK#A77"
-
-+ [PK#A78 / SK#A78]
-+   PK: "PK#A78"
-+   SK: "SK#A78"
-+   _docVersion: 0
-+   _tag: "A"
-+   a: 78
-+   pk: "PK#A78"
-+   sk: "SK#A78"
-
-+ [PK#A79 / SK#A79]
-+   PK: "PK#A79"
-+   SK: "SK#A79"
-+   _docVersion: 0
-+   _tag: "A"
-+   a: 79
-+   pk: "PK#A79"
-+   sk: "SK#A79"
-
-+ [PK#A8 / SK#A8]
-+   PK: "PK#A8"
-+   SK: "SK#A8"
-+   _docVersion: 0
-+   _tag: "A"
-+   a: 8
-+   pk: "PK#A8"
-+   sk: "SK#A8"
-
-+ [PK#A80 / SK#A80]
-+   PK: "PK#A80"
-+   SK: "SK#A80"
-+   _docVersion: 0
-+   _tag: "A"
-+   a: 80
-+   pk: "PK#A80"
-+   sk: "SK#A80"
-
-+ [PK#A81 / SK#A81]
-+   PK: "PK#A81"
-+   SK: "SK#A81"
-+   _docVersion: 0
-+   _tag: "A"
-+   a: 81
-+   pk: "PK#A81"
-+   sk: "SK#A81"
-
-+ [PK#A82 / SK#A82]
-+   PK: "PK#A82"
-+   SK: "SK#A82"
-+   _docVersion: 0
-+   _tag: "A"
-+   a: 82
-+   pk: "PK#A82"
-+   sk: "SK#A82"
-
-+ [PK#A83 / SK#A83]
-+   PK: "PK#A83"
-+   SK: "SK#A83"
-+   _docVersion: 0
-+   _tag: "A"
-+   a: 83
-+   pk: "PK#A83"
-+   sk: "SK#A83"
-
-+ [PK#A84 / SK#A84]
-+   PK: "PK#A84"
-+   SK: "SK#A84"
-+   _docVersion: 0
-+   _tag: "A"
-+   a: 84
-+   pk: "PK#A84"
-+   sk: "SK#A84"
-
-+ [PK#A85 / SK#A85]
-+   PK: "PK#A85"
-+   SK: "SK#A85"
-+   _docVersion: 0
-+   _tag: "A"
-+   a: 85
-+   pk: "PK#A85"
-+   sk: "SK#A85"
-
-+ [PK#A86 / SK#A86]
-+   PK: "PK#A86"
-+   SK: "SK#A86"
-+   _docVersion: 0
-+   _tag: "A"
-+   a: 86
-+   pk: "PK#A86"
-+   sk: "SK#A86"
-
-+ [PK#A87 / SK#A87]
-+   PK: "PK#A87"
-+   SK: "SK#A87"
-+   _docVersion: 0
-+   _tag: "A"
-+   a: 87
-+   pk: "PK#A87"
-+   sk: "SK#A87"
-
-+ [PK#A88 / SK#A88]
-+   PK: "PK#A88"
-+   SK: "SK#A88"
-+   _docVersion: 0
-+   _tag: "A"
-+   a: 88
-+   pk: "PK#A88"
-+   sk: "SK#A88"
-
-+ [PK#A89 / SK#A89]
-+   PK: "PK#A89"
-+   SK: "SK#A89"
-+   _docVersion: 0
-+   _tag: "A"
-+   a: 89
-+   pk: "PK#A89"
-+   sk: "SK#A89"
-
-+ [PK#A9 / SK#A9]
-+   PK: "PK#A9"
-+   SK: "SK#A9"
-+   _docVersion: 0
-+   _tag: "A"
-+   a: 9
-+   pk: "PK#A9"
-+   sk: "SK#A9"
-
-+ [PK#A90 / SK#A90]
-+   PK: "PK#A90"
-+   SK: "SK#A90"
-+   _docVersion: 0
-+   _tag: "A"
-+   a: 90
-+   pk: "PK#A90"
-+   sk: "SK#A90"
-
-+ [PK#A91 / SK#A91]
-+   PK: "PK#A91"
-+   SK: "SK#A91"
-+   _docVersion: 0
-+   _tag: "A"
-+   a: 91
-+   pk: "PK#A91"
-+   sk: "SK#A91"
-
-+ [PK#A92 / SK#A92]
-+   PK: "PK#A92"
-+   SK: "SK#A92"
-+   _docVersion: 0
-+   _tag: "A"
-+   a: 92
-+   pk: "PK#A92"
-+   sk: "SK#A92"
-
-+ [PK#A93 / SK#A93]
-+   PK: "PK#A93"
-+   SK: "SK#A93"
-+   _docVersion: 0
-+   _tag: "A"
-+   a: 93
-+   pk: "PK#A93"
-+   sk: "SK#A93"
-
-+ [PK#A94 / SK#A94]
-+   PK: "PK#A94"
-+   SK: "SK#A94"
-+   _docVersion: 0
-+   _tag: "A"
-+   a: 94
-+   pk: "PK#A94"
-+   sk: "SK#A94"
-
-+ [PK#A95 / SK#A95]
-+   PK: "PK#A95"
-+   SK: "SK#A95"
-+   _docVersion: 0
-+   _tag: "A"
-+   a: 95
-+   pk: "PK#A95"
-+   sk: "SK#A95"
-
-+ [PK#A96 / SK#A96]
-+   PK: "PK#A96"
-+   SK: "SK#A96"
-+   _docVersion: 0
-+   _tag: "A"
-+   a: 96
-+   pk: "PK#A96"
-+   sk: "SK#A96"
-
-+ [PK#A97 / SK#A97]
-+   PK: "PK#A97"
-+   SK: "SK#A97"
-+   _docVersion: 0
-+   _tag: "A"
-+   a: 97
-+   pk: "PK#A97"
-+   sk: "SK#A97"
-
-+ [PK#A98 / SK#A98]
-+   PK: "PK#A98"
-+   SK: "SK#A98"
-+   _docVersion: 0
-+   _tag: "A"
-+   a: 98
-+   pk: "PK#A98"
-+   sk: "SK#A98"
-
-+ [PK#A99 / SK#A99]
-+   PK: "PK#A99"
-+   SK: "SK#A99"
-+   _docVersion: 0
-+   _tag: "A"
-+   a: 99
-+   pk: "PK#A99"
-+   sk: "SK#A99"
-
-+ [PK#UPDATE / SK#UPDATE]
-+   PK: "PK#UPDATE"
-+   SK: "SK#UPDATE"
-+   _docVersion: 1
-+   _tag: "B"
-+   b: "baz"
-+   pk: "PK#UPDATE"
-+   sk: "SK#UPDATE"
-
-+ [PK4 / PK4]
-+   PK: "PK4"
-+   SK: "PK4"
-+   _docVersion: 0
-+   _tag: "A"
-+   a: 4
-+   pk: "PK4"
-+   sk: "PK4"
-
-+ [PK5 / PK5]
-+   PK: "PK5"
-+   SK: "PK5"
-+   _docVersion: 0
-+   _tag: "A"
-+   a: 5
-+   pk: "PK5"
-+   sk: "PK5"
-
-+ [PK6 / SK6]
-+   PK: "PK6"
-+   SK: "SK6"
-+   _docVersion: 0
-+   _tag: "B"
-+   b: "baz"
-+   pk: "PK6"
-+   sk: "SK6"
-`)
+        [PK#1 / SK#1]
+            PK: "PK#1"
+            SK: "SK#1"
+            _docVersion: 0
+            _tag: "A"
+        -   a: 1
+        +   a: -1
+            pk: "PK#1"
+            sk: "SK#1"
+
+        - [PK#2 / SK#2]
+        -   PK: "PK#2"
+        -   SK: "SK#2"
+        -   _docVersion: 0
+        -   _tag: "A"
+        -   a: 2
+        -   pk: "PK#2"
+        -   sk: "SK#2"
+
+        - [PK#3 / SK#3]
+        -   PK: "PK#3"
+        -   SK: "SK#3"
+        -   _docVersion: 0
+        -   _tag: "B"
+        -   b: "bar"
+        -   pk: "PK#3"
+        -   sk: "SK#3"
+
+        + [PK#A0 / SK#A0]
+        +   PK: "PK#A0"
+        +   SK: "SK#A0"
+        +   _docVersion: 0
+        +   _tag: "A"
+        +   a: 0
+        +   pk: "PK#A0"
+        +   sk: "SK#A0"
+
+        + [PK#A1 / SK#A1]
+        +   PK: "PK#A1"
+        +   SK: "SK#A1"
+        +   _docVersion: 0
+        +   _tag: "A"
+        +   a: 1
+        +   pk: "PK#A1"
+        +   sk: "SK#A1"
+
+        + [PK#A10 / SK#A10]
+        +   PK: "PK#A10"
+        +   SK: "SK#A10"
+        +   _docVersion: 0
+        +   _tag: "A"
+        +   a: 10
+        +   pk: "PK#A10"
+        +   sk: "SK#A10"
+
+        + [PK#A11 / SK#A11]
+        +   PK: "PK#A11"
+        +   SK: "SK#A11"
+        +   _docVersion: 0
+        +   _tag: "A"
+        +   a: 11
+        +   pk: "PK#A11"
+        +   sk: "SK#A11"
+
+        + [PK#A12 / SK#A12]
+        +   PK: "PK#A12"
+        +   SK: "SK#A12"
+        +   _docVersion: 0
+        +   _tag: "A"
+        +   a: 12
+        +   pk: "PK#A12"
+        +   sk: "SK#A12"
+
+        + [PK#A13 / SK#A13]
+        +   PK: "PK#A13"
+        +   SK: "SK#A13"
+        +   _docVersion: 0
+        +   _tag: "A"
+        +   a: 13
+        +   pk: "PK#A13"
+        +   sk: "SK#A13"
+
+        + [PK#A14 / SK#A14]
+        +   PK: "PK#A14"
+        +   SK: "SK#A14"
+        +   _docVersion: 0
+        +   _tag: "A"
+        +   a: 14
+        +   pk: "PK#A14"
+        +   sk: "SK#A14"
+
+        + [PK#A15 / SK#A15]
+        +   PK: "PK#A15"
+        +   SK: "SK#A15"
+        +   _docVersion: 0
+        +   _tag: "A"
+        +   a: 15
+        +   pk: "PK#A15"
+        +   sk: "SK#A15"
+
+        + [PK#A16 / SK#A16]
+        +   PK: "PK#A16"
+        +   SK: "SK#A16"
+        +   _docVersion: 0
+        +   _tag: "A"
+        +   a: 16
+        +   pk: "PK#A16"
+        +   sk: "SK#A16"
+
+        + [PK#A17 / SK#A17]
+        +   PK: "PK#A17"
+        +   SK: "SK#A17"
+        +   _docVersion: 0
+        +   _tag: "A"
+        +   a: 17
+        +   pk: "PK#A17"
+        +   sk: "SK#A17"
+
+        + [PK#A18 / SK#A18]
+        +   PK: "PK#A18"
+        +   SK: "SK#A18"
+        +   _docVersion: 0
+        +   _tag: "A"
+        +   a: 18
+        +   pk: "PK#A18"
+        +   sk: "SK#A18"
+
+        + [PK#A19 / SK#A19]
+        +   PK: "PK#A19"
+        +   SK: "SK#A19"
+        +   _docVersion: 0
+        +   _tag: "A"
+        +   a: 19
+        +   pk: "PK#A19"
+        +   sk: "SK#A19"
+
+        + [PK#A2 / SK#A2]
+        +   PK: "PK#A2"
+        +   SK: "SK#A2"
+        +   _docVersion: 0
+        +   _tag: "A"
+        +   a: 2
+        +   pk: "PK#A2"
+        +   sk: "SK#A2"
+
+        + [PK#A20 / SK#A20]
+        +   PK: "PK#A20"
+        +   SK: "SK#A20"
+        +   _docVersion: 0
+        +   _tag: "A"
+        +   a: 20
+        +   pk: "PK#A20"
+        +   sk: "SK#A20"
+
+        + [PK#A21 / SK#A21]
+        +   PK: "PK#A21"
+        +   SK: "SK#A21"
+        +   _docVersion: 0
+        +   _tag: "A"
+        +   a: 21
+        +   pk: "PK#A21"
+        +   sk: "SK#A21"
+
+        + [PK#A22 / SK#A22]
+        +   PK: "PK#A22"
+        +   SK: "SK#A22"
+        +   _docVersion: 0
+        +   _tag: "A"
+        +   a: 22
+        +   pk: "PK#A22"
+        +   sk: "SK#A22"
+
+        + [PK#A23 / SK#A23]
+        +   PK: "PK#A23"
+        +   SK: "SK#A23"
+        +   _docVersion: 0
+        +   _tag: "A"
+        +   a: 23
+        +   pk: "PK#A23"
+        +   sk: "SK#A23"
+
+        + [PK#A24 / SK#A24]
+        +   PK: "PK#A24"
+        +   SK: "SK#A24"
+        +   _docVersion: 0
+        +   _tag: "A"
+        +   a: 24
+        +   pk: "PK#A24"
+        +   sk: "SK#A24"
+
+        + [PK#A25 / SK#A25]
+        +   PK: "PK#A25"
+        +   SK: "SK#A25"
+        +   _docVersion: 0
+        +   _tag: "A"
+        +   a: 25
+        +   pk: "PK#A25"
+        +   sk: "SK#A25"
+
+        + [PK#A26 / SK#A26]
+        +   PK: "PK#A26"
+        +   SK: "SK#A26"
+        +   _docVersion: 0
+        +   _tag: "A"
+        +   a: 26
+        +   pk: "PK#A26"
+        +   sk: "SK#A26"
+
+        + [PK#A27 / SK#A27]
+        +   PK: "PK#A27"
+        +   SK: "SK#A27"
+        +   _docVersion: 0
+        +   _tag: "A"
+        +   a: 27
+        +   pk: "PK#A27"
+        +   sk: "SK#A27"
+
+        + [PK#A28 / SK#A28]
+        +   PK: "PK#A28"
+        +   SK: "SK#A28"
+        +   _docVersion: 0
+        +   _tag: "A"
+        +   a: 28
+        +   pk: "PK#A28"
+        +   sk: "SK#A28"
+
+        + [PK#A29 / SK#A29]
+        +   PK: "PK#A29"
+        +   SK: "SK#A29"
+        +   _docVersion: 0
+        +   _tag: "A"
+        +   a: 29
+        +   pk: "PK#A29"
+        +   sk: "SK#A29"
+
+        + [PK#A3 / SK#A3]
+        +   PK: "PK#A3"
+        +   SK: "SK#A3"
+        +   _docVersion: 0
+        +   _tag: "A"
+        +   a: 3
+        +   pk: "PK#A3"
+        +   sk: "SK#A3"
+
+        + [PK#A30 / SK#A30]
+        +   PK: "PK#A30"
+        +   SK: "SK#A30"
+        +   _docVersion: 0
+        +   _tag: "A"
+        +   a: 30
+        +   pk: "PK#A30"
+        +   sk: "SK#A30"
+
+        + [PK#A31 / SK#A31]
+        +   PK: "PK#A31"
+        +   SK: "SK#A31"
+        +   _docVersion: 0
+        +   _tag: "A"
+        +   a: 31
+        +   pk: "PK#A31"
+        +   sk: "SK#A31"
+
+        + [PK#A32 / SK#A32]
+        +   PK: "PK#A32"
+        +   SK: "SK#A32"
+        +   _docVersion: 0
+        +   _tag: "A"
+        +   a: 32
+        +   pk: "PK#A32"
+        +   sk: "SK#A32"
+
+        + [PK#A33 / SK#A33]
+        +   PK: "PK#A33"
+        +   SK: "SK#A33"
+        +   _docVersion: 0
+        +   _tag: "A"
+        +   a: 33
+        +   pk: "PK#A33"
+        +   sk: "SK#A33"
+
+        + [PK#A34 / SK#A34]
+        +   PK: "PK#A34"
+        +   SK: "SK#A34"
+        +   _docVersion: 0
+        +   _tag: "A"
+        +   a: 34
+        +   pk: "PK#A34"
+        +   sk: "SK#A34"
+
+        + [PK#A35 / SK#A35]
+        +   PK: "PK#A35"
+        +   SK: "SK#A35"
+        +   _docVersion: 0
+        +   _tag: "A"
+        +   a: 35
+        +   pk: "PK#A35"
+        +   sk: "SK#A35"
+
+        + [PK#A36 / SK#A36]
+        +   PK: "PK#A36"
+        +   SK: "SK#A36"
+        +   _docVersion: 0
+        +   _tag: "A"
+        +   a: 36
+        +   pk: "PK#A36"
+        +   sk: "SK#A36"
+
+        + [PK#A37 / SK#A37]
+        +   PK: "PK#A37"
+        +   SK: "SK#A37"
+        +   _docVersion: 0
+        +   _tag: "A"
+        +   a: 37
+        +   pk: "PK#A37"
+        +   sk: "SK#A37"
+
+        + [PK#A38 / SK#A38]
+        +   PK: "PK#A38"
+        +   SK: "SK#A38"
+        +   _docVersion: 0
+        +   _tag: "A"
+        +   a: 38
+        +   pk: "PK#A38"
+        +   sk: "SK#A38"
+
+        + [PK#A39 / SK#A39]
+        +   PK: "PK#A39"
+        +   SK: "SK#A39"
+        +   _docVersion: 0
+        +   _tag: "A"
+        +   a: 39
+        +   pk: "PK#A39"
+        +   sk: "SK#A39"
+
+        + [PK#A4 / SK#A4]
+        +   PK: "PK#A4"
+        +   SK: "SK#A4"
+        +   _docVersion: 0
+        +   _tag: "A"
+        +   a: 4
+        +   pk: "PK#A4"
+        +   sk: "SK#A4"
+
+        + [PK#A40 / SK#A40]
+        +   PK: "PK#A40"
+        +   SK: "SK#A40"
+        +   _docVersion: 0
+        +   _tag: "A"
+        +   a: 40
+        +   pk: "PK#A40"
+        +   sk: "SK#A40"
+
+        + [PK#A41 / SK#A41]
+        +   PK: "PK#A41"
+        +   SK: "SK#A41"
+        +   _docVersion: 0
+        +   _tag: "A"
+        +   a: 41
+        +   pk: "PK#A41"
+        +   sk: "SK#A41"
+
+        + [PK#A42 / SK#A42]
+        +   PK: "PK#A42"
+        +   SK: "SK#A42"
+        +   _docVersion: 0
+        +   _tag: "A"
+        +   a: 42
+        +   pk: "PK#A42"
+        +   sk: "SK#A42"
+
+        + [PK#A43 / SK#A43]
+        +   PK: "PK#A43"
+        +   SK: "SK#A43"
+        +   _docVersion: 0
+        +   _tag: "A"
+        +   a: 43
+        +   pk: "PK#A43"
+        +   sk: "SK#A43"
+
+        + [PK#A44 / SK#A44]
+        +   PK: "PK#A44"
+        +   SK: "SK#A44"
+        +   _docVersion: 0
+        +   _tag: "A"
+        +   a: 44
+        +   pk: "PK#A44"
+        +   sk: "SK#A44"
+
+        + [PK#A45 / SK#A45]
+        +   PK: "PK#A45"
+        +   SK: "SK#A45"
+        +   _docVersion: 0
+        +   _tag: "A"
+        +   a: 45
+        +   pk: "PK#A45"
+        +   sk: "SK#A45"
+
+        + [PK#A46 / SK#A46]
+        +   PK: "PK#A46"
+        +   SK: "SK#A46"
+        +   _docVersion: 0
+        +   _tag: "A"
+        +   a: 46
+        +   pk: "PK#A46"
+        +   sk: "SK#A46"
+
+        + [PK#A47 / SK#A47]
+        +   PK: "PK#A47"
+        +   SK: "SK#A47"
+        +   _docVersion: 0
+        +   _tag: "A"
+        +   a: 47
+        +   pk: "PK#A47"
+        +   sk: "SK#A47"
+
+        + [PK#A48 / SK#A48]
+        +   PK: "PK#A48"
+        +   SK: "SK#A48"
+        +   _docVersion: 0
+        +   _tag: "A"
+        +   a: 48
+        +   pk: "PK#A48"
+        +   sk: "SK#A48"
+
+        + [PK#A49 / SK#A49]
+        +   PK: "PK#A49"
+        +   SK: "SK#A49"
+        +   _docVersion: 0
+        +   _tag: "A"
+        +   a: 49
+        +   pk: "PK#A49"
+        +   sk: "SK#A49"
+
+        + [PK#A5 / SK#A5]
+        +   PK: "PK#A5"
+        +   SK: "SK#A5"
+        +   _docVersion: 0
+        +   _tag: "A"
+        +   a: 5
+        +   pk: "PK#A5"
+        +   sk: "SK#A5"
+
+        + [PK#A50 / SK#A50]
+        +   PK: "PK#A50"
+        +   SK: "SK#A50"
+        +   _docVersion: 0
+        +   _tag: "A"
+        +   a: 50
+        +   pk: "PK#A50"
+        +   sk: "SK#A50"
+
+        + [PK#A51 / SK#A51]
+        +   PK: "PK#A51"
+        +   SK: "SK#A51"
+        +   _docVersion: 0
+        +   _tag: "A"
+        +   a: 51
+        +   pk: "PK#A51"
+        +   sk: "SK#A51"
+
+        + [PK#A52 / SK#A52]
+        +   PK: "PK#A52"
+        +   SK: "SK#A52"
+        +   _docVersion: 0
+        +   _tag: "A"
+        +   a: 52
+        +   pk: "PK#A52"
+        +   sk: "SK#A52"
+
+        + [PK#A53 / SK#A53]
+        +   PK: "PK#A53"
+        +   SK: "SK#A53"
+        +   _docVersion: 0
+        +   _tag: "A"
+        +   a: 53
+        +   pk: "PK#A53"
+        +   sk: "SK#A53"
+
+        + [PK#A54 / SK#A54]
+        +   PK: "PK#A54"
+        +   SK: "SK#A54"
+        +   _docVersion: 0
+        +   _tag: "A"
+        +   a: 54
+        +   pk: "PK#A54"
+        +   sk: "SK#A54"
+
+        + [PK#A55 / SK#A55]
+        +   PK: "PK#A55"
+        +   SK: "SK#A55"
+        +   _docVersion: 0
+        +   _tag: "A"
+        +   a: 55
+        +   pk: "PK#A55"
+        +   sk: "SK#A55"
+
+        + [PK#A56 / SK#A56]
+        +   PK: "PK#A56"
+        +   SK: "SK#A56"
+        +   _docVersion: 0
+        +   _tag: "A"
+        +   a: 56
+        +   pk: "PK#A56"
+        +   sk: "SK#A56"
+
+        + [PK#A57 / SK#A57]
+        +   PK: "PK#A57"
+        +   SK: "SK#A57"
+        +   _docVersion: 0
+        +   _tag: "A"
+        +   a: 57
+        +   pk: "PK#A57"
+        +   sk: "SK#A57"
+
+        + [PK#A58 / SK#A58]
+        +   PK: "PK#A58"
+        +   SK: "SK#A58"
+        +   _docVersion: 0
+        +   _tag: "A"
+        +   a: 58
+        +   pk: "PK#A58"
+        +   sk: "SK#A58"
+
+        + [PK#A59 / SK#A59]
+        +   PK: "PK#A59"
+        +   SK: "SK#A59"
+        +   _docVersion: 0
+        +   _tag: "A"
+        +   a: 59
+        +   pk: "PK#A59"
+        +   sk: "SK#A59"
+
+        + [PK#A6 / SK#A6]
+        +   PK: "PK#A6"
+        +   SK: "SK#A6"
+        +   _docVersion: 0
+        +   _tag: "A"
+        +   a: 6
+        +   pk: "PK#A6"
+        +   sk: "SK#A6"
+
+        + [PK#A60 / SK#A60]
+        +   PK: "PK#A60"
+        +   SK: "SK#A60"
+        +   _docVersion: 0
+        +   _tag: "A"
+        +   a: 60
+        +   pk: "PK#A60"
+        +   sk: "SK#A60"
+
+        + [PK#A61 / SK#A61]
+        +   PK: "PK#A61"
+        +   SK: "SK#A61"
+        +   _docVersion: 0
+        +   _tag: "A"
+        +   a: 61
+        +   pk: "PK#A61"
+        +   sk: "SK#A61"
+
+        + [PK#A62 / SK#A62]
+        +   PK: "PK#A62"
+        +   SK: "SK#A62"
+        +   _docVersion: 0
+        +   _tag: "A"
+        +   a: 62
+        +   pk: "PK#A62"
+        +   sk: "SK#A62"
+
+        + [PK#A63 / SK#A63]
+        +   PK: "PK#A63"
+        +   SK: "SK#A63"
+        +   _docVersion: 0
+        +   _tag: "A"
+        +   a: 63
+        +   pk: "PK#A63"
+        +   sk: "SK#A63"
+
+        + [PK#A64 / SK#A64]
+        +   PK: "PK#A64"
+        +   SK: "SK#A64"
+        +   _docVersion: 0
+        +   _tag: "A"
+        +   a: 64
+        +   pk: "PK#A64"
+        +   sk: "SK#A64"
+
+        + [PK#A65 / SK#A65]
+        +   PK: "PK#A65"
+        +   SK: "SK#A65"
+        +   _docVersion: 0
+        +   _tag: "A"
+        +   a: 65
+        +   pk: "PK#A65"
+        +   sk: "SK#A65"
+
+        + [PK#A66 / SK#A66]
+        +   PK: "PK#A66"
+        +   SK: "SK#A66"
+        +   _docVersion: 0
+        +   _tag: "A"
+        +   a: 66
+        +   pk: "PK#A66"
+        +   sk: "SK#A66"
+
+        + [PK#A67 / SK#A67]
+        +   PK: "PK#A67"
+        +   SK: "SK#A67"
+        +   _docVersion: 0
+        +   _tag: "A"
+        +   a: 67
+        +   pk: "PK#A67"
+        +   sk: "SK#A67"
+
+        + [PK#A68 / SK#A68]
+        +   PK: "PK#A68"
+        +   SK: "SK#A68"
+        +   _docVersion: 0
+        +   _tag: "A"
+        +   a: 68
+        +   pk: "PK#A68"
+        +   sk: "SK#A68"
+
+        + [PK#A69 / SK#A69]
+        +   PK: "PK#A69"
+        +   SK: "SK#A69"
+        +   _docVersion: 0
+        +   _tag: "A"
+        +   a: 69
+        +   pk: "PK#A69"
+        +   sk: "SK#A69"
+
+        + [PK#A7 / SK#A7]
+        +   PK: "PK#A7"
+        +   SK: "SK#A7"
+        +   _docVersion: 0
+        +   _tag: "A"
+        +   a: 7
+        +   pk: "PK#A7"
+        +   sk: "SK#A7"
+
+        + [PK#A70 / SK#A70]
+        +   PK: "PK#A70"
+        +   SK: "SK#A70"
+        +   _docVersion: 0
+        +   _tag: "A"
+        +   a: 70
+        +   pk: "PK#A70"
+        +   sk: "SK#A70"
+
+        + [PK#A71 / SK#A71]
+        +   PK: "PK#A71"
+        +   SK: "SK#A71"
+        +   _docVersion: 0
+        +   _tag: "A"
+        +   a: 71
+        +   pk: "PK#A71"
+        +   sk: "SK#A71"
+
+        + [PK#A72 / SK#A72]
+        +   PK: "PK#A72"
+        +   SK: "SK#A72"
+        +   _docVersion: 0
+        +   _tag: "A"
+        +   a: 72
+        +   pk: "PK#A72"
+        +   sk: "SK#A72"
+
+        + [PK#A73 / SK#A73]
+        +   PK: "PK#A73"
+        +   SK: "SK#A73"
+        +   _docVersion: 0
+        +   _tag: "A"
+        +   a: 73
+        +   pk: "PK#A73"
+        +   sk: "SK#A73"
+
+        + [PK#A74 / SK#A74]
+        +   PK: "PK#A74"
+        +   SK: "SK#A74"
+        +   _docVersion: 0
+        +   _tag: "A"
+        +   a: 74
+        +   pk: "PK#A74"
+        +   sk: "SK#A74"
+
+        + [PK#A75 / SK#A75]
+        +   PK: "PK#A75"
+        +   SK: "SK#A75"
+        +   _docVersion: 0
+        +   _tag: "A"
+        +   a: 75
+        +   pk: "PK#A75"
+        +   sk: "SK#A75"
+
+        + [PK#A76 / SK#A76]
+        +   PK: "PK#A76"
+        +   SK: "SK#A76"
+        +   _docVersion: 0
+        +   _tag: "A"
+        +   a: 76
+        +   pk: "PK#A76"
+        +   sk: "SK#A76"
+
+        + [PK#A77 / SK#A77]
+        +   PK: "PK#A77"
+        +   SK: "SK#A77"
+        +   _docVersion: 0
+        +   _tag: "A"
+        +   a: 77
+        +   pk: "PK#A77"
+        +   sk: "SK#A77"
+
+        + [PK#A78 / SK#A78]
+        +   PK: "PK#A78"
+        +   SK: "SK#A78"
+        +   _docVersion: 0
+        +   _tag: "A"
+        +   a: 78
+        +   pk: "PK#A78"
+        +   sk: "SK#A78"
+
+        + [PK#A79 / SK#A79]
+        +   PK: "PK#A79"
+        +   SK: "SK#A79"
+        +   _docVersion: 0
+        +   _tag: "A"
+        +   a: 79
+        +   pk: "PK#A79"
+        +   sk: "SK#A79"
+
+        + [PK#A8 / SK#A8]
+        +   PK: "PK#A8"
+        +   SK: "SK#A8"
+        +   _docVersion: 0
+        +   _tag: "A"
+        +   a: 8
+        +   pk: "PK#A8"
+        +   sk: "SK#A8"
+
+        + [PK#A80 / SK#A80]
+        +   PK: "PK#A80"
+        +   SK: "SK#A80"
+        +   _docVersion: 0
+        +   _tag: "A"
+        +   a: 80
+        +   pk: "PK#A80"
+        +   sk: "SK#A80"
+
+        + [PK#A81 / SK#A81]
+        +   PK: "PK#A81"
+        +   SK: "SK#A81"
+        +   _docVersion: 0
+        +   _tag: "A"
+        +   a: 81
+        +   pk: "PK#A81"
+        +   sk: "SK#A81"
+
+        + [PK#A82 / SK#A82]
+        +   PK: "PK#A82"
+        +   SK: "SK#A82"
+        +   _docVersion: 0
+        +   _tag: "A"
+        +   a: 82
+        +   pk: "PK#A82"
+        +   sk: "SK#A82"
+
+        + [PK#A83 / SK#A83]
+        +   PK: "PK#A83"
+        +   SK: "SK#A83"
+        +   _docVersion: 0
+        +   _tag: "A"
+        +   a: 83
+        +   pk: "PK#A83"
+        +   sk: "SK#A83"
+
+        + [PK#A84 / SK#A84]
+        +   PK: "PK#A84"
+        +   SK: "SK#A84"
+        +   _docVersion: 0
+        +   _tag: "A"
+        +   a: 84
+        +   pk: "PK#A84"
+        +   sk: "SK#A84"
+
+        + [PK#A85 / SK#A85]
+        +   PK: "PK#A85"
+        +   SK: "SK#A85"
+        +   _docVersion: 0
+        +   _tag: "A"
+        +   a: 85
+        +   pk: "PK#A85"
+        +   sk: "SK#A85"
+
+        + [PK#A86 / SK#A86]
+        +   PK: "PK#A86"
+        +   SK: "SK#A86"
+        +   _docVersion: 0
+        +   _tag: "A"
+        +   a: 86
+        +   pk: "PK#A86"
+        +   sk: "SK#A86"
+
+        + [PK#A87 / SK#A87]
+        +   PK: "PK#A87"
+        +   SK: "SK#A87"
+        +   _docVersion: 0
+        +   _tag: "A"
+        +   a: 87
+        +   pk: "PK#A87"
+        +   sk: "SK#A87"
+
+        + [PK#A88 / SK#A88]
+        +   PK: "PK#A88"
+        +   SK: "SK#A88"
+        +   _docVersion: 0
+        +   _tag: "A"
+        +   a: 88
+        +   pk: "PK#A88"
+        +   sk: "SK#A88"
+
+        + [PK#A89 / SK#A89]
+        +   PK: "PK#A89"
+        +   SK: "SK#A89"
+        +   _docVersion: 0
+        +   _tag: "A"
+        +   a: 89
+        +   pk: "PK#A89"
+        +   sk: "SK#A89"
+
+        + [PK#A9 / SK#A9]
+        +   PK: "PK#A9"
+        +   SK: "SK#A9"
+        +   _docVersion: 0
+        +   _tag: "A"
+        +   a: 9
+        +   pk: "PK#A9"
+        +   sk: "SK#A9"
+
+        + [PK#A90 / SK#A90]
+        +   PK: "PK#A90"
+        +   SK: "SK#A90"
+        +   _docVersion: 0
+        +   _tag: "A"
+        +   a: 90
+        +   pk: "PK#A90"
+        +   sk: "SK#A90"
+
+        + [PK#A91 / SK#A91]
+        +   PK: "PK#A91"
+        +   SK: "SK#A91"
+        +   _docVersion: 0
+        +   _tag: "A"
+        +   a: 91
+        +   pk: "PK#A91"
+        +   sk: "SK#A91"
+
+        + [PK#A92 / SK#A92]
+        +   PK: "PK#A92"
+        +   SK: "SK#A92"
+        +   _docVersion: 0
+        +   _tag: "A"
+        +   a: 92
+        +   pk: "PK#A92"
+        +   sk: "SK#A92"
+
+        + [PK#A93 / SK#A93]
+        +   PK: "PK#A93"
+        +   SK: "SK#A93"
+        +   _docVersion: 0
+        +   _tag: "A"
+        +   a: 93
+        +   pk: "PK#A93"
+        +   sk: "SK#A93"
+
+        + [PK#A94 / SK#A94]
+        +   PK: "PK#A94"
+        +   SK: "SK#A94"
+        +   _docVersion: 0
+        +   _tag: "A"
+        +   a: 94
+        +   pk: "PK#A94"
+        +   sk: "SK#A94"
+
+        + [PK#A95 / SK#A95]
+        +   PK: "PK#A95"
+        +   SK: "SK#A95"
+        +   _docVersion: 0
+        +   _tag: "A"
+        +   a: 95
+        +   pk: "PK#A95"
+        +   sk: "SK#A95"
+
+        + [PK#A96 / SK#A96]
+        +   PK: "PK#A96"
+        +   SK: "SK#A96"
+        +   _docVersion: 0
+        +   _tag: "A"
+        +   a: 96
+        +   pk: "PK#A96"
+        +   sk: "SK#A96"
+
+        + [PK#A97 / SK#A97]
+        +   PK: "PK#A97"
+        +   SK: "SK#A97"
+        +   _docVersion: 0
+        +   _tag: "A"
+        +   a: 97
+        +   pk: "PK#A97"
+        +   sk: "SK#A97"
+
+        + [PK#A98 / SK#A98]
+        +   PK: "PK#A98"
+        +   SK: "SK#A98"
+        +   _docVersion: 0
+        +   _tag: "A"
+        +   a: 98
+        +   pk: "PK#A98"
+        +   sk: "SK#A98"
+
+        + [PK#A99 / SK#A99]
+        +   PK: "PK#A99"
+        +   SK: "SK#A99"
+        +   _docVersion: 0
+        +   _tag: "A"
+        +   a: 99
+        +   pk: "PK#A99"
+        +   sk: "SK#A99"
+
+        + [PK#UPDATE / SK#UPDATE]
+        +   PK: "PK#UPDATE"
+        +   SK: "SK#UPDATE"
+        +   _docVersion: 1
+        +   _tag: "B"
+        +   b: "baz"
+        +   pk: "PK#UPDATE"
+        +   sk: "SK#UPDATE"
+
+        + [PK4 / PK4]
+        +   PK: "PK4"
+        +   SK: "PK4"
+        +   _docVersion: 0
+        +   _tag: "A"
+        +   a: 4
+        +   pk: "PK4"
+        +   sk: "PK4"
+
+        + [PK5 / PK5]
+        +   PK: "PK5"
+        +   SK: "PK5"
+        +   _docVersion: 0
+        +   _tag: "A"
+        +   a: 5
+        +   pk: "PK5"
+        +   sk: "PK5"
+
+        + [PK6 / SK6]
+        +   PK: "PK6"
+        +   SK: "SK6"
+        +   _docVersion: 0
+        +   _tag: "B"
+        +   b: "baz"
+        +   pk: "PK6"
+        +   sk: "SK6"
+      `)
       //#endregion
     })
 
@@ -2192,28 +2194,28 @@ describe("batchGet", () => {
         Object.entries(results).map(([key, val]) => [key, val.values()])
       )
     ).toMatchInlineSnapshot(`
-      Object {
-        "duplicate": Object {
+      {
+        "duplicate": {
           "a": 1,
           "pk": "PK#1",
           "sk": "SK#1",
         },
-        "four": Object {
+        "four": {
           "a": 4,
           "pk": "PK#4",
           "sk": "SK#4",
         },
-        "one": Object {
+        "one": {
           "a": 1,
           "pk": "PK#1",
           "sk": "SK#1",
         },
-        "three": Object {
+        "three": {
           "a": 3,
           "pk": "PK#3",
           "sk": "SK#3",
         },
-        "two": Object {
+        "two": {
           "a": 2,
           "pk": "PK#2",
           "sk": "SK#2",
@@ -2433,7 +2435,7 @@ describe("paginate", () => {
         }
       )
       expect(page1.pageInfo).toMatchInlineSnapshot(`
-        Object {
+        {
           "endCursor": "cC4wNVXawu0oBvB8vqW4J/RG6hbr3ndOo7vfn9aOeA8=",
           "hasNextPage": true,
           "hasPreviousPage": false,
@@ -2453,7 +2455,7 @@ describe("paginate", () => {
         }
       )
       expect(page2.pageInfo).toMatchInlineSnapshot(`
-        Object {
+        {
           "endCursor": "cC4wNVXawu0oBvB8vqW4J/RG6hbr3ndOo5Xfn9aOeA8=",
           "hasNextPage": true,
           "hasPreviousPage": false,
@@ -2473,7 +2475,7 @@ describe("paginate", () => {
         }
       )
       expect(page3.pageInfo).toMatchInlineSnapshot(`
-        Object {
+        {
           "endCursor": "cC4wNVXawu0oBvB8vqW4J/RG6hbr3ndOoLvfn9aOeA8=",
           "hasNextPage": false,
           "hasPreviousPage": false,
@@ -2494,7 +2496,7 @@ describe("paginate", () => {
         }
       )
       expect(backwardsPage2.pageInfo).toMatchInlineSnapshot(`
-        Object {
+        {
           "endCursor": "cC4wNVXawu0oBvB8vqW4J/RG6hbr3ndOo5Xfn9aOeA8=",
           "hasNextPage": false,
           "hasPreviousPage": true,
@@ -2514,7 +2516,7 @@ describe("paginate", () => {
         }
       )
       expect(backwardsPage1.pageInfo).toMatchInlineSnapshot(`
-        Object {
+        {
           "endCursor": "cC4wNVXawu0oBvB8vqW4J/RG6hbr3ndOo7vfn9aOeA8=",
           "hasNextPage": false,
           "hasPreviousPage": false,
@@ -2545,7 +2547,7 @@ describe("paginate", () => {
         }
       )
       expect(page1.pageInfo).toMatchInlineSnapshot(`
-        Object {
+        {
           "endCursor": "cC4wNVXawu0oBvB8vqW4J/RG6hbr3ndOo7vfn9aOeA8=",
           "hasNextPage": true,
           "hasPreviousPage": false,
@@ -2565,7 +2567,7 @@ describe("paginate", () => {
         }
       )
       expect(page2.pageInfo).toMatchInlineSnapshot(`
-        Object {
+        {
           "endCursor": "cC4wNVXawu0oBvB8vqW4J/RG6hbr3ndOo5Xfn9aOeA8=",
           "hasNextPage": true,
           "hasPreviousPage": false,
@@ -2585,7 +2587,7 @@ describe("paginate", () => {
         }
       )
       expect(page3.pageInfo).toMatchInlineSnapshot(`
-        Object {
+        {
           "endCursor": "cC4wNVXawu0oBvB8vqW4J/RG6hbr3ndOoLvfn9aOeA8=",
           "hasNextPage": false,
           "hasPreviousPage": false,
@@ -2606,7 +2608,7 @@ describe("paginate", () => {
         }
       )
       expect(backwardsPage2.pageInfo).toMatchInlineSnapshot(`
-        Object {
+        {
           "endCursor": "cC4wNVXawu0oBvB8vqW4J/RG6hbr3ndOo5Xfn9aOeA8=",
           "hasNextPage": false,
           "hasPreviousPage": true,
@@ -2626,7 +2628,7 @@ describe("paginate", () => {
         }
       )
       expect(backwardsPage1.pageInfo).toMatchInlineSnapshot(`
-        Object {
+        {
           "endCursor": "cC4wNVXawu0oBvB8vqW4J/RG6hbr3ndOo7vfn9aOeA8=",
           "hasNextPage": false,
           "hasPreviousPage": false,
@@ -2656,7 +2658,7 @@ describe("paginate", () => {
         }
       )
       expect(page.pageInfo).toMatchInlineSnapshot(`
-        Object {
+        {
           "endCursor": "cC4wNVXawu0oBvB8vqW4J/RG6hbr3ndOo6vfn9aOeA8=",
           "hasNextPage": true,
           "hasPreviousPage": false,
@@ -2686,7 +2688,7 @@ describe("paginate", () => {
         }
       )
       expect(page1.pageInfo).toMatchInlineSnapshot(`
-        Object {
+        {
           "endCursor": "cC4wNVXawu0oBvB8vqW4J/RG6hbr3ndOoKvfn9aOeA8=",
           "hasNextPage": true,
           "hasPreviousPage": false,
@@ -2767,7 +2769,7 @@ describe("paginate", () => {
         }
       )
       expect(page1.pageInfo).toMatchInlineSnapshot(`
-        Object {
+        {
           "endCursor": "cC4wNVXawu0oBvB8vqW4J/RG6hbr3ndOo7vfn9aOeA8=",
           "hasNextPage": true,
           "hasPreviousPage": false,
@@ -2786,7 +2788,7 @@ describe("paginate", () => {
         }
       )
       expect(page2.pageInfo).toMatchInlineSnapshot(`
-        Object {
+        {
           "endCursor": "cC4wNVXawu0oBvB8vqW4J/RG6hbr3ndOo5Xfn9aOeA8=",
           "hasNextPage": true,
           "hasPreviousPage": false,
@@ -2805,7 +2807,7 @@ describe("paginate", () => {
         }
       )
       expect(page3.pageInfo).toMatchInlineSnapshot(`
-        Object {
+        {
           "endCursor": "cC4wNVXawu0oBvB8vqW4J/RG6hbr3ndOoLvfn9aOeA8=",
           "hasNextPage": false,
           "hasPreviousPage": false,
@@ -2825,7 +2827,7 @@ describe("paginate", () => {
         }
       )
       expect(backwardsPage2.pageInfo).toMatchInlineSnapshot(`
-        Object {
+        {
           "endCursor": "cC4wNVXawu0oBvB8vqW4J/RG6hbr3ndOo5Xfn9aOeA8=",
           "hasNextPage": false,
           "hasPreviousPage": true,
@@ -2844,7 +2846,7 @@ describe("paginate", () => {
         }
       )
       expect(backwardsPage1.pageInfo).toMatchInlineSnapshot(`
-        Object {
+        {
           "endCursor": "cC4wNVXawu0oBvB8vqW4J/RG6hbr3ndOo7vfn9aOeA8=",
           "hasNextPage": false,
           "hasPreviousPage": false,
@@ -2873,7 +2875,7 @@ describe("paginate", () => {
         }
       )
       expect(page.pageInfo).toMatchInlineSnapshot(`
-        Object {
+        {
           "endCursor": "cC4wNVXawu0oBvB8vqW4J/RG6hbr3ndOo6vfn9aOeA8=",
           "hasNextPage": true,
           "hasPreviousPage": false,
@@ -2902,7 +2904,7 @@ describe("paginate", () => {
         }
       )
       expect(page1.pageInfo).toMatchInlineSnapshot(`
-        Object {
+        {
           "endCursor": "cC4wNVXawu0oBvB8vqW4J/RG6hbr3ndOoKvfn9aOeA8=",
           "hasNextPage": true,
           "hasPreviousPage": false,
@@ -2982,7 +2984,7 @@ describe("paginate", () => {
         }
       )
       expect(page1.pageInfo).toMatchInlineSnapshot(`
-        Object {
+        {
           "endCursor": "cC4wNVXawu0oBvB8vqW4J/RG6hbr3ndOo7vfn9aOeA8=",
           "hasNextPage": true,
           "hasPreviousPage": false,
@@ -3001,7 +3003,7 @@ describe("paginate", () => {
         }
       )
       expect(page2.pageInfo).toMatchInlineSnapshot(`
-        Object {
+        {
           "endCursor": "cC4wNVXawu0oBvB8vqW4J/RG6hbr3ndOo5Xfn9aOeA8=",
           "hasNextPage": true,
           "hasPreviousPage": false,
@@ -3020,7 +3022,7 @@ describe("paginate", () => {
         }
       )
       expect(page3.pageInfo).toMatchInlineSnapshot(`
-        Object {
+        {
           "endCursor": "cC4wNVXawu0oBvB8vqW4J/RG6hbr3ndOoLvfn9aOeA8=",
           "hasNextPage": false,
           "hasPreviousPage": false,
@@ -3040,7 +3042,7 @@ describe("paginate", () => {
         }
       )
       expect(backwardsPage2.pageInfo).toMatchInlineSnapshot(`
-        Object {
+        {
           "endCursor": "cC4wNVXawu0oBvB8vqW4J/RG6hbr3ndOo5Xfn9aOeA8=",
           "hasNextPage": false,
           "hasPreviousPage": true,
@@ -3059,7 +3061,7 @@ describe("paginate", () => {
         }
       )
       expect(backwardsPage1.pageInfo).toMatchInlineSnapshot(`
-        Object {
+        {
           "endCursor": "cC4wNVXawu0oBvB8vqW4J/RG6hbr3ndOo7vfn9aOeA8=",
           "hasNextPage": false,
           "hasPreviousPage": false,
@@ -3089,7 +3091,7 @@ describe("paginate", () => {
         }
       )
       expect(page.pageInfo).toMatchInlineSnapshot(`
-        Object {
+        {
           "endCursor": "cC4wNVXawu0oBvB8vqW4J/RG6hbr3ndOo6vfn9aOeA8=",
           "hasNextPage": true,
           "hasPreviousPage": false,
@@ -3119,7 +3121,7 @@ describe("paginate", () => {
         }
       )
       expect(page1.pageInfo).toMatchInlineSnapshot(`
-        Object {
+        {
           "endCursor": "cC4wNVXawu0oBvB8vqW4J/RG6hbr3ndOoKvfn9aOeA8=",
           "hasNextPage": true,
           "hasPreviousPage": false,

--- a/packages/dynamodb/src/__test__/client.test.ts
+++ b/packages/dynamodb/src/__test__/client.test.ts
@@ -146,14 +146,14 @@ describe("put", () => {
       await new Simple({ foo: "hi", bar: 42 }).put()
 
       expect(await sandbox.diff(before)).toMatchInlineSnapshot(`
-+ [PK#hi / SK#42]
-+   PK: "PK#hi"
-+   SK: "SK#42"
-+   _docVersion: 0
-+   _tag: "Simple"
-+   bar: 42
-+   foo: "hi"
-`)
+        + [PK#hi / SK#42]
+        +   PK: "PK#hi"
+        +   SK: "SK#42"
+        +   _docVersion: 0
+        +   _tag: "Simple"
+        +   bar: 42
+        +   foo: "hi"
+      `)
     })
 
     test("it inserts a model with single gsi", async () => {
@@ -162,16 +162,16 @@ describe("put", () => {
       await new SingleGSI({ foo: "yes", bar: 42 }).put()
 
       expect(await sandbox.diff(before)).toMatchInlineSnapshot(`
-+ [PK#yes / SK#42]
-+   PK: "PK#yes"
-+   SK: "SK#42"
-+   GSI2PK: "GSI2PK#yesyes"
-+   GSI2SK: "GSI2SK#FIXED"
-+   _docVersion: 0
-+   _tag: "SingleGSI"
-+   bar: 42
-+   foo: "yes"
-`)
+        + [PK#yes / SK#42]
+        +   PK: "PK#yes"
+        +   SK: "SK#42"
+        +   GSI2PK: "GSI2PK#yesyes"
+        +   GSI2SK: "GSI2SK#FIXED"
+        +   _docVersion: 0
+        +   _tag: "SingleGSI"
+        +   bar: 42
+        +   foo: "yes"
+      `)
     })
 
     test("it inserts a model with multiple gsi", async () => {
@@ -180,22 +180,22 @@ describe("put", () => {
       await new MultiGSI({ foo: "yes", bar: 42 }).put()
 
       expect(await sandbox.diff(before)).toMatchInlineSnapshot(`
-+ [PK#yes / SK#42]
-+   PK: "PK#yes"
-+   SK: "SK#42"
-+   GSI2PK: "GSI2PK#yesyes"
-+   GSI2SK: "GSI2SK#FIXED"
-+   GSI3PK: "GSI3PK#FIXED"
-+   GSI3SK: "GSI3SK#4242"
-+   GSI4PK: "GSI4PK#FIXED"
-+   GSI4SK: "GSI4SK#4242"
-+   GSI5PK: "GSI5PK#FIXED"
-+   GSI5SK: "GSI5SK#4242"
-+   _docVersion: 0
-+   _tag: "MultiGSI"
-+   bar: 42
-+   foo: "yes"
-`)
+        + [PK#yes / SK#42]
+        +   PK: "PK#yes"
+        +   SK: "SK#42"
+        +   GSI2PK: "GSI2PK#yesyes"
+        +   GSI2SK: "GSI2SK#FIXED"
+        +   GSI3PK: "GSI3PK#FIXED"
+        +   GSI3SK: "GSI3SK#4242"
+        +   GSI4PK: "GSI4PK#FIXED"
+        +   GSI4SK: "GSI4SK#4242"
+        +   GSI5PK: "GSI5PK#FIXED"
+        +   GSI5SK: "GSI5SK#4242"
+        +   _docVersion: 0
+        +   _tag: "MultiGSI"
+        +   bar: 42
+        +   foo: "yes"
+      `)
     })
 
     test("it throws KeyExistsError if item exists", async () => {
@@ -222,14 +222,14 @@ describe("put", () => {
       await Simple.put(new Simple({ foo: "hi", bar: 42 }))
 
       expect(await sandbox.diff(before)).toMatchInlineSnapshot(`
-+ [PK#hi / SK#42]
-+   PK: "PK#hi"
-+   SK: "SK#42"
-+   _docVersion: 0
-+   _tag: "Simple"
-+   bar: 42
-+   foo: "hi"
-`)
+        + [PK#hi / SK#42]
+        +   PK: "PK#hi"
+        +   SK: "SK#42"
+        +   _docVersion: 0
+        +   _tag: "Simple"
+        +   bar: 42
+        +   foo: "hi"
+      `)
     })
 
     test("it inserts a model with single gsi", async () => {
@@ -238,16 +238,16 @@ describe("put", () => {
       await SingleGSI.put(new SingleGSI({ foo: "yes", bar: 42 }))
 
       expect(await sandbox.diff(before)).toMatchInlineSnapshot(`
-+ [PK#yes / SK#42]
-+   PK: "PK#yes"
-+   SK: "SK#42"
-+   GSI2PK: "GSI2PK#yesyes"
-+   GSI2SK: "GSI2SK#FIXED"
-+   _docVersion: 0
-+   _tag: "SingleGSI"
-+   bar: 42
-+   foo: "yes"
-`)
+        + [PK#yes / SK#42]
+        +   PK: "PK#yes"
+        +   SK: "SK#42"
+        +   GSI2PK: "GSI2PK#yesyes"
+        +   GSI2SK: "GSI2SK#FIXED"
+        +   _docVersion: 0
+        +   _tag: "SingleGSI"
+        +   bar: 42
+        +   foo: "yes"
+      `)
     })
 
     test("it inserts a model with multiple gsi", async () => {
@@ -256,22 +256,22 @@ describe("put", () => {
       await MultiGSI.put(new MultiGSI({ foo: "yes", bar: 42 }))
 
       expect(await sandbox.diff(before)).toMatchInlineSnapshot(`
-+ [PK#yes / SK#42]
-+   PK: "PK#yes"
-+   SK: "SK#42"
-+   GSI2PK: "GSI2PK#yesyes"
-+   GSI2SK: "GSI2SK#FIXED"
-+   GSI3PK: "GSI3PK#FIXED"
-+   GSI3SK: "GSI3SK#4242"
-+   GSI4PK: "GSI4PK#FIXED"
-+   GSI4SK: "GSI4SK#4242"
-+   GSI5PK: "GSI5PK#FIXED"
-+   GSI5SK: "GSI5SK#4242"
-+   _docVersion: 0
-+   _tag: "MultiGSI"
-+   bar: 42
-+   foo: "yes"
-`)
+        + [PK#yes / SK#42]
+        +   PK: "PK#yes"
+        +   SK: "SK#42"
+        +   GSI2PK: "GSI2PK#yesyes"
+        +   GSI2SK: "GSI2SK#FIXED"
+        +   GSI3PK: "GSI3PK#FIXED"
+        +   GSI3SK: "GSI3SK#4242"
+        +   GSI4PK: "GSI4PK#FIXED"
+        +   GSI4SK: "GSI4SK#4242"
+        +   GSI5PK: "GSI5PK#FIXED"
+        +   GSI5SK: "GSI5SK#4242"
+        +   _docVersion: 0
+        +   _tag: "MultiGSI"
+        +   bar: 42
+        +   foo: "yes"
+      `)
     })
 
     test("it throws KeyExistsError if item exists", async () => {
@@ -311,11 +311,11 @@ describe("get", () => {
       })
 
       expect(result.values()).toMatchInlineSnapshot(`
-              Object {
-                "bar": 432,
-                "foo": "hi",
-              }
-          `)
+        {
+          "bar": 432,
+          "foo": "hi",
+        }
+      `)
 
       expect(result.encode()).toEqual(item.encode())
     })
@@ -343,7 +343,7 @@ describe("get", () => {
 
       expect(result).toBeInstanceOf(C)
       expect(result.values()).toMatchInlineSnapshot(`
-        Object {
+        {
           "c": "0",
           "pk": "PK#0",
           "sk": "SK#0",
@@ -380,14 +380,14 @@ describe("delete", () => {
       expect(result).toBeNull()
 
       expect(await sandbox.diff(before)).toMatchInlineSnapshot(`
-- [PK#hi / SK#432]
--   PK: "PK#hi"
--   SK: "SK#432"
--   _docVersion: 0
--   _tag: "Simple"
--   bar: 432
--   foo: "hi"
-`)
+        - [PK#hi / SK#432]
+        -   PK: "PK#hi"
+        -   SK: "SK#432"
+        -   _docVersion: 0
+        -   _tag: "Simple"
+        -   bar: 432
+        -   foo: "hi"
+      `)
     })
   })
 
@@ -405,14 +405,14 @@ describe("delete", () => {
       expect(result).toBeNull()
 
       expect(await sandbox.diff(before)).toMatchInlineSnapshot(`
-- [PK#hi / SK#432]
--   PK: "PK#hi"
--   SK: "SK#432"
--   _docVersion: 0
--   _tag: "Simple"
--   bar: 432
--   foo: "hi"
-`)
+        - [PK#hi / SK#432]
+        -   PK: "PK#hi"
+        -   SK: "SK#432"
+        -   _docVersion: 0
+        -   _tag: "Simple"
+        -   bar: 432
+        -   foo: "hi"
+      `)
     })
   })
 
@@ -427,14 +427,14 @@ describe("delete", () => {
       expect(result).toBeNull()
 
       expect(await sandbox.diff(before)).toMatchInlineSnapshot(`
-- [PK#hi / SK#432]
--   PK: "PK#hi"
--   SK: "SK#432"
--   _docVersion: 0
--   _tag: "Simple"
--   bar: 432
--   foo: "hi"
-`)
+        - [PK#hi / SK#432]
+        -   PK: "PK#hi"
+        -   SK: "SK#432"
+        -   _docVersion: 0
+        -   _tag: "Simple"
+        -   bar: 432
+        -   foo: "hi"
+      `)
     })
   })
 })
@@ -451,69 +451,69 @@ describe("softDelete", () => {
       const withGSIResult = await client.softDelete(withGSI)
 
       expect(simpleResult.values()).toMatchInlineSnapshot(`
-        Object {
+        {
           "bar": 432,
           "foo": "hi",
         }
       `)
       expect(withGSIResult.values()).toMatchInlineSnapshot(`
-        Object {
+        {
           "bar": 42,
           "foo": "hello",
         }
       `)
 
       expect(await sandbox.diff(before)).toMatchInlineSnapshot(`
-+ [$$DELETED$$PK#hello / $$DELETED$$SK#42]
-+   PK: "$$DELETED$$PK#hello"
-+   SK: "$$DELETED$$SK#42"
-+   GSI2PK: "$$DELETED$$GSI2PK#hellohello"
-+   GSI2SK: "$$DELETED$$GSI2SK#FIXED"
-+   GSI3PK: "$$DELETED$$GSI3PK#FIXED"
-+   GSI3SK: "$$DELETED$$GSI3SK#4242"
-+   GSI4PK: "$$DELETED$$GSI4PK#FIXED"
-+   GSI4SK: "$$DELETED$$GSI4SK#4242"
-+   GSI5PK: "$$DELETED$$GSI5PK#FIXED"
-+   GSI5SK: "$$DELETED$$GSI5SK#4242"
-+   _deletedAt: "2021-05-01T08:00:00.000Z"
-+   _docVersion: 0
-+   _tag: "MultiGSI"
-+   bar: 42
-+   foo: "hello"
+        + [$$DELETED$$PK#hello / $$DELETED$$SK#42]
+        +   PK: "$$DELETED$$PK#hello"
+        +   SK: "$$DELETED$$SK#42"
+        +   GSI2PK: "$$DELETED$$GSI2PK#hellohello"
+        +   GSI2SK: "$$DELETED$$GSI2SK#FIXED"
+        +   GSI3PK: "$$DELETED$$GSI3PK#FIXED"
+        +   GSI3SK: "$$DELETED$$GSI3SK#4242"
+        +   GSI4PK: "$$DELETED$$GSI4PK#FIXED"
+        +   GSI4SK: "$$DELETED$$GSI4SK#4242"
+        +   GSI5PK: "$$DELETED$$GSI5PK#FIXED"
+        +   GSI5SK: "$$DELETED$$GSI5SK#4242"
+        +   _deletedAt: "2021-05-01T08:00:00.000Z"
+        +   _docVersion: 0
+        +   _tag: "MultiGSI"
+        +   bar: 42
+        +   foo: "hello"
 
-+ [$$DELETED$$PK#hi / $$DELETED$$SK#432]
-+   PK: "$$DELETED$$PK#hi"
-+   SK: "$$DELETED$$SK#432"
-+   _deletedAt: "2021-05-01T08:00:00.000Z"
-+   _docVersion: 0
-+   _tag: "Simple"
-+   bar: 432
-+   foo: "hi"
+        + [$$DELETED$$PK#hi / $$DELETED$$SK#432]
+        +   PK: "$$DELETED$$PK#hi"
+        +   SK: "$$DELETED$$SK#432"
+        +   _deletedAt: "2021-05-01T08:00:00.000Z"
+        +   _docVersion: 0
+        +   _tag: "Simple"
+        +   bar: 432
+        +   foo: "hi"
 
-- [PK#hello / SK#42]
--   PK: "PK#hello"
--   SK: "SK#42"
--   GSI2PK: "GSI2PK#hellohello"
--   GSI2SK: "GSI2SK#FIXED"
--   GSI3PK: "GSI3PK#FIXED"
--   GSI3SK: "GSI3SK#4242"
--   GSI4PK: "GSI4PK#FIXED"
--   GSI4SK: "GSI4SK#4242"
--   GSI5PK: "GSI5PK#FIXED"
--   GSI5SK: "GSI5SK#4242"
--   _docVersion: 0
--   _tag: "MultiGSI"
--   bar: 42
--   foo: "hello"
+        - [PK#hello / SK#42]
+        -   PK: "PK#hello"
+        -   SK: "SK#42"
+        -   GSI2PK: "GSI2PK#hellohello"
+        -   GSI2SK: "GSI2SK#FIXED"
+        -   GSI3PK: "GSI3PK#FIXED"
+        -   GSI3SK: "GSI3SK#4242"
+        -   GSI4PK: "GSI4PK#FIXED"
+        -   GSI4SK: "GSI4SK#4242"
+        -   GSI5PK: "GSI5PK#FIXED"
+        -   GSI5SK: "GSI5SK#4242"
+        -   _docVersion: 0
+        -   _tag: "MultiGSI"
+        -   bar: 42
+        -   foo: "hello"
 
-- [PK#hi / SK#432]
--   PK: "PK#hi"
--   SK: "SK#432"
--   _docVersion: 0
--   _tag: "Simple"
--   bar: 432
--   foo: "hi"
-`)
+        - [PK#hi / SK#432]
+        -   PK: "PK#hi"
+        -   SK: "SK#432"
+        -   _docVersion: 0
+        -   _tag: "Simple"
+        -   bar: 432
+        -   foo: "hi"
+      `)
     })
   })
 
@@ -526,30 +526,30 @@ describe("softDelete", () => {
       const result = await Simple.softDelete(item)
 
       expect(result.values()).toMatchInlineSnapshot(`
-        Object {
+        {
           "bar": 432,
           "foo": "hi",
         }
       `)
 
       expect(await sandbox.diff(before)).toMatchInlineSnapshot(`
-+ [$$DELETED$$PK#hi / $$DELETED$$SK#432]
-+   PK: "$$DELETED$$PK#hi"
-+   SK: "$$DELETED$$SK#432"
-+   _deletedAt: "2021-05-01T08:00:00.000Z"
-+   _docVersion: 0
-+   _tag: "Simple"
-+   bar: 432
-+   foo: "hi"
+        + [$$DELETED$$PK#hi / $$DELETED$$SK#432]
+        +   PK: "$$DELETED$$PK#hi"
+        +   SK: "$$DELETED$$SK#432"
+        +   _deletedAt: "2021-05-01T08:00:00.000Z"
+        +   _docVersion: 0
+        +   _tag: "Simple"
+        +   bar: 432
+        +   foo: "hi"
 
-- [PK#hi / SK#432]
--   PK: "PK#hi"
--   SK: "SK#432"
--   _docVersion: 0
--   _tag: "Simple"
--   bar: 432
--   foo: "hi"
-`)
+        - [PK#hi / SK#432]
+        -   PK: "PK#hi"
+        -   SK: "SK#432"
+        -   _docVersion: 0
+        -   _tag: "Simple"
+        -   bar: 432
+        -   foo: "hi"
+      `)
     })
   })
 
@@ -562,30 +562,30 @@ describe("softDelete", () => {
       const result = await item.softDelete()
 
       expect(result.values()).toMatchInlineSnapshot(`
-        Object {
+        {
           "bar": 432,
           "foo": "hi",
         }
       `)
 
       expect(await sandbox.diff(before)).toMatchInlineSnapshot(`
-+ [$$DELETED$$PK#hi / $$DELETED$$SK#432]
-+   PK: "$$DELETED$$PK#hi"
-+   SK: "$$DELETED$$SK#432"
-+   _deletedAt: "2021-05-01T08:00:00.000Z"
-+   _docVersion: 0
-+   _tag: "Simple"
-+   bar: 432
-+   foo: "hi"
+        + [$$DELETED$$PK#hi / $$DELETED$$SK#432]
+        +   PK: "$$DELETED$$PK#hi"
+        +   SK: "$$DELETED$$SK#432"
+        +   _deletedAt: "2021-05-01T08:00:00.000Z"
+        +   _docVersion: 0
+        +   _tag: "Simple"
+        +   bar: 432
+        +   foo: "hi"
 
-- [PK#hi / SK#432]
--   PK: "PK#hi"
--   SK: "SK#432"
--   _docVersion: 0
--   _tag: "Simple"
--   bar: 432
--   foo: "hi"
-`)
+        - [PK#hi / SK#432]
+        -   PK: "PK#hi"
+        -   SK: "SK#432"
+        -   _docVersion: 0
+        -   _tag: "Simple"
+        -   bar: 432
+        -   foo: "hi"
+      `)
     })
   })
 })
@@ -619,8 +619,8 @@ describe("updateRaw", () => {
     // that it is not reflected in the DB!
     expect(result.PK).toEqual(`PK#new foo`)
     expect(await sandbox.snapshot()).toMatchInlineSnapshot(`
-      Object {
-        "PK#old__SK#43": Object {
+      {
+        "PK#old__SK#43": {
           "PK": "PK#old",
           "SK": "SK#43",
           "_docVersion": 0,
@@ -655,8 +655,8 @@ describe("update", () => {
       await item.update({ foo: "ciao" })
 
       expect(await sandbox.snapshot()).toMatchInlineSnapshot(`
-        Object {
-          "FIXEDPK__FIXEDSK": Object {
+        {
+          "FIXEDPK__FIXEDSK": {
             "PK": "FIXEDPK",
             "SK": "FIXEDSK",
             "_docVersion": 1,
@@ -684,23 +684,23 @@ describe("update", () => {
 
       expect((await item.update({ foo: "ciao" })).values())
         .toMatchInlineSnapshot(`
-        Object {
+        {
           "bar": 1,
           "foo": "ciao",
         }
       `)
 
       expect(await sandbox.diff(before)).toMatchInlineSnapshot(`
-[FIXEDPK / FIXEDSK]
-    PK: "FIXEDPK"
-    SK: "FIXEDSK"
--   _docVersion: 0
-+   _docVersion: 1
-    _tag: "InPlace"
-    bar: 1
--   foo: "hello"
-+   foo: "ciao"
-`)
+        [FIXEDPK / FIXEDSK]
+            PK: "FIXEDPK"
+            SK: "FIXEDSK"
+        -   _docVersion: 0
+        +   _docVersion: 1
+            _tag: "InPlace"
+            bar: 1
+        -   foo: "hello"
+        +   foo: "ciao"
+      `)
     })
   })
 })
@@ -713,7 +713,7 @@ describe("applyUpdate", () => {
 
     const [updatedItem, updateOp] = item.applyUpdate({ a: 2 })
     expect(updatedItem.values()).toMatchInlineSnapshot(`
-      Object {
+      {
         "a": 2,
         "pk": "PK",
         "sk": "SK",
@@ -723,17 +723,17 @@ describe("applyUpdate", () => {
     await client.bulk([updateOp])
 
     expect(await sandbox.diff(before)).toMatchInlineSnapshot(`
-[PK / SK]
-    PK: "PK"
-    SK: "SK"
--   _docVersion: 0
-+   _docVersion: 1
-    _tag: "A"
--   a: 1
-+   a: 2
-    pk: "PK"
-    sk: "SK"
-`)
+      [PK / SK]
+          PK: "PK"
+          SK: "SK"
+      -   _docVersion: 0
+      +   _docVersion: 1
+          _tag: "A"
+      -   a: 1
+      +   a: 2
+          pk: "PK"
+          sk: "SK"
+    `)
   })
 })
 
@@ -746,19 +746,20 @@ describe("query", () => {
             KeyConditionExpression: `PK = :pk and begins_with(SK, :sk)`,
             ExpressionAttributeValues: { ":pk": "abc", ":sk": "SORT" }
           },
+
           { a: A, b: B, union: Union }
         )
       ).toMatchInlineSnapshot(`
-              Object {
-                "_unknown": Array [],
-                "a": Array [],
-                "b": Array [],
-                "meta": Object {
-                  "lastEvaluatedKey": undefined,
-                },
-                "union": Array [],
-              }
-          `)
+        {
+          "_unknown": [],
+          "a": [],
+          "b": [],
+          "meta": {
+            "lastEvaluatedKey": undefined,
+          },
+          "union": [],
+        }
+      `)
     })
 
     test("it returns unknown results", async () => {
@@ -770,25 +771,26 @@ describe("query", () => {
             KeyConditionExpression: `PK = :pk and begins_with(SK, :sk)`,
             ExpressionAttributeValues: { ":pk": "abc", ":sk": "SORT#" }
           },
+
           { a: A, b: B, union: Union }
         )
       ).toMatchInlineSnapshot(`
-              Object {
-                "_unknown": Array [
-                  Object {
-                    "PK": "abc",
-                    "SK": "SORT#1",
-                    "doesnt": "match",
-                  },
-                ],
-                "a": Array [],
-                "b": Array [],
-                "meta": Object {
-                  "lastEvaluatedKey": undefined,
-                },
-                "union": Array [],
-              }
-          `)
+        {
+          "_unknown": [
+            {
+              "PK": "abc",
+              "SK": "SORT#1",
+              "doesnt": "match",
+            },
+          ],
+          "a": [],
+          "b": [],
+          "meta": {
+            "lastEvaluatedKey": undefined,
+          },
+          "union": [],
+        }
+      `)
     })
 
     test("it returns results", async () => {
@@ -816,50 +818,50 @@ describe("query", () => {
         b: b.map(item => item.values()),
         union: union.map(item => item.values())
       }).toMatchInlineSnapshot(`
-              Object {
-                "_unknown": Array [
-                  Object {
-                    "PK": "abc",
-                    "SK": "SORT#4",
-                    "probably": "unknown",
-                  },
-                ],
-                "a": Array [
-                  Object {
-                    "a": 1,
-                    "pk": "abc",
-                    "sk": "SORT#1",
-                  },
-                  Object {
-                    "a": 2,
-                    "pk": "abc",
-                    "sk": "SORT#2",
-                  },
-                ],
-                "b": Array [
-                  Object {
-                    "b": "hi",
-                    "pk": "abc",
-                    "sk": "SORT#3",
-                  },
-                ],
-                "meta": Object {
-                  "lastEvaluatedKey": undefined,
-                },
-                "union": Array [
-                  Object {
-                    "c": "hi",
-                    "pk": "abc",
-                    "sk": "SORT#5",
-                  },
-                  Object {
-                    "d": "hi",
-                    "pk": "abc",
-                    "sk": "SORT#6",
-                  },
-                ],
-              }
-          `)
+        {
+          "_unknown": [
+            {
+              "PK": "abc",
+              "SK": "SORT#4",
+              "probably": "unknown",
+            },
+          ],
+          "a": [
+            {
+              "a": 1,
+              "pk": "abc",
+              "sk": "SORT#1",
+            },
+            {
+              "a": 2,
+              "pk": "abc",
+              "sk": "SORT#2",
+            },
+          ],
+          "b": [
+            {
+              "b": "hi",
+              "pk": "abc",
+              "sk": "SORT#3",
+            },
+          ],
+          "meta": {
+            "lastEvaluatedKey": undefined,
+          },
+          "union": [
+            {
+              "c": "hi",
+              "pk": "abc",
+              "sk": "SORT#5",
+            },
+            {
+              "d": "hi",
+              "pk": "abc",
+              "sk": "SORT#6",
+            },
+          ],
+        }
+      `)
     })
 
     test("it paginates", async () => {
@@ -959,13 +961,13 @@ describe("query", () => {
 
       expect(result.length).toBe(2)
       expect(result.map(item => item.values())).toMatchInlineSnapshot(`
-        Array [
-          Object {
+        [
+          {
             "a": 1,
             "pk": "abc",
             "sk": "SORT#1",
           },
-          Object {
+          {
             "a": 2,
             "pk": "abc",
             "sk": "SORT#2",
@@ -1223,82 +1225,82 @@ describe("bulk", () => {
       ])
 
       expect(await sandbox.diff(before)).toMatchInlineSnapshot(`
-+ [$$DELETED$$PK#3 / $$DELETED$$SK#3]
-+   PK: "$$DELETED$$PK#3"
-+   SK: "$$DELETED$$SK#3"
-+   _deletedAt: "2021-05-01T08:00:00.000Z"
-+   _docVersion: 0
-+   _tag: "B"
-+   b: "bar"
-+   pk: "PK#3"
-+   sk: "SK#3"
+        + [$$DELETED$$PK#3 / $$DELETED$$SK#3]
+        +   PK: "$$DELETED$$PK#3"
+        +   SK: "$$DELETED$$SK#3"
+        +   _deletedAt: "2021-05-01T08:00:00.000Z"
+        +   _docVersion: 0
+        +   _tag: "B"
+        +   b: "bar"
+        +   pk: "PK#3"
+        +   sk: "SK#3"
 
-[PK#1 / SK#1]
-    PK: "PK#1"
-    SK: "SK#1"
-    _docVersion: 0
-    _tag: "A"
--   a: 1
-+   a: -1
-    pk: "PK#1"
-    sk: "SK#1"
+        [PK#1 / SK#1]
+            PK: "PK#1"
+            SK: "SK#1"
+            _docVersion: 0
+            _tag: "A"
+        -   a: 1
+        +   a: -1
+            pk: "PK#1"
+            sk: "SK#1"
 
-- [PK#2 / SK#2]
--   PK: "PK#2"
--   SK: "SK#2"
--   _docVersion: 0
--   _tag: "A"
--   a: 2
--   pk: "PK#2"
--   sk: "SK#2"
+        - [PK#2 / SK#2]
+        -   PK: "PK#2"
+        -   SK: "SK#2"
+        -   _docVersion: 0
+        -   _tag: "A"
+        -   a: 2
+        -   pk: "PK#2"
+        -   sk: "SK#2"
 
-- [PK#3 / SK#3]
--   PK: "PK#3"
--   SK: "SK#3"
--   _docVersion: 0
--   _tag: "B"
--   b: "bar"
--   pk: "PK#3"
--   sk: "SK#3"
+        - [PK#3 / SK#3]
+        -   PK: "PK#3"
+        -   SK: "SK#3"
+        -   _docVersion: 0
+        -   _tag: "B"
+        -   b: "bar"
+        -   pk: "PK#3"
+        -   sk: "SK#3"
 
-[PK#UPDATE / SK#UPDATE]
-    PK: "PK#UPDATE"
-    SK: "SK#UPDATE"
--   _docVersion: 0
-+   _docVersion: 1
-    _tag: "B"
--   b: "bar"
-+   b: "baz"
-    pk: "PK#UPDATE"
-    sk: "SK#UPDATE"
+        [PK#UPDATE / SK#UPDATE]
+            PK: "PK#UPDATE"
+            SK: "SK#UPDATE"
+        -   _docVersion: 0
+        +   _docVersion: 1
+            _tag: "B"
+        -   b: "bar"
+        +   b: "baz"
+            pk: "PK#UPDATE"
+            sk: "SK#UPDATE"
 
-+ [PK4 / PK4]
-+   PK: "PK4"
-+   SK: "PK4"
-+   _docVersion: 0
-+   _tag: "A"
-+   a: 4
-+   pk: "PK4"
-+   sk: "PK4"
+        + [PK4 / PK4]
+        +   PK: "PK4"
+        +   SK: "PK4"
+        +   _docVersion: 0
+        +   _tag: "A"
+        +   a: 4
+        +   pk: "PK4"
+        +   sk: "PK4"
 
-+ [PK5 / PK5]
-+   PK: "PK5"
-+   SK: "PK5"
-+   _docVersion: 0
-+   _tag: "A"
-+   a: 5
-+   pk: "PK5"
-+   sk: "PK5"
+        + [PK5 / PK5]
+        +   PK: "PK5"
+        +   SK: "PK5"
+        +   _docVersion: 0
+        +   _tag: "A"
+        +   a: 5
+        +   pk: "PK5"
+        +   sk: "PK5"
 
-+ [PK6 / SK6]
-+   PK: "PK6"
-+   SK: "SK6"
-+   _docVersion: 0
-+   _tag: "B"
-+   b: "baz"
-+   pk: "PK6"
-+   sk: "SK6"
-`)
+        + [PK6 / SK6]
+        +   PK: "PK6"
+        +   SK: "SK6"
+        +   _docVersion: 0
+        +   _tag: "B"
+        +   b: "baz"
+        +   pk: "PK6"
+        +   sk: "SK6"
+      `)
     })
 
     test("it fails", async () => {
@@ -1361,970 +1363,970 @@ describe("bulk", () => {
 
       //#region snapshot
       expect(await sandbox.diff(before)).toMatchInlineSnapshot(`
-[PK#1 / SK#1]
-    PK: "PK#1"
-    SK: "SK#1"
-    _docVersion: 0
-    _tag: "A"
--   a: 1
-+   a: -1
-    pk: "PK#1"
-    sk: "SK#1"
-
-- [PK#2 / SK#2]
--   PK: "PK#2"
--   SK: "SK#2"
--   _docVersion: 0
--   _tag: "A"
--   a: 2
--   pk: "PK#2"
--   sk: "SK#2"
-
-- [PK#3 / SK#3]
--   PK: "PK#3"
--   SK: "SK#3"
--   _docVersion: 0
--   _tag: "B"
--   b: "bar"
--   pk: "PK#3"
--   sk: "SK#3"
-
-+ [PK#A0 / SK#A0]
-+   PK: "PK#A0"
-+   SK: "SK#A0"
-+   _docVersion: 0
-+   _tag: "A"
-+   a: 0
-+   pk: "PK#A0"
-+   sk: "SK#A0"
-
-+ [PK#A1 / SK#A1]
-+   PK: "PK#A1"
-+   SK: "SK#A1"
-+   _docVersion: 0
-+   _tag: "A"
-+   a: 1
-+   pk: "PK#A1"
-+   sk: "SK#A1"
-
-+ [PK#A10 / SK#A10]
-+   PK: "PK#A10"
-+   SK: "SK#A10"
-+   _docVersion: 0
-+   _tag: "A"
-+   a: 10
-+   pk: "PK#A10"
-+   sk: "SK#A10"
-
-+ [PK#A11 / SK#A11]
-+   PK: "PK#A11"
-+   SK: "SK#A11"
-+   _docVersion: 0
-+   _tag: "A"
-+   a: 11
-+   pk: "PK#A11"
-+   sk: "SK#A11"
-
-+ [PK#A12 / SK#A12]
-+   PK: "PK#A12"
-+   SK: "SK#A12"
-+   _docVersion: 0
-+   _tag: "A"
-+   a: 12
-+   pk: "PK#A12"
-+   sk: "SK#A12"
-
-+ [PK#A13 / SK#A13]
-+   PK: "PK#A13"
-+   SK: "SK#A13"
-+   _docVersion: 0
-+   _tag: "A"
-+   a: 13
-+   pk: "PK#A13"
-+   sk: "SK#A13"
-
-+ [PK#A14 / SK#A14]
-+   PK: "PK#A14"
-+   SK: "SK#A14"
-+   _docVersion: 0
-+   _tag: "A"
-+   a: 14
-+   pk: "PK#A14"
-+   sk: "SK#A14"
-
-+ [PK#A15 / SK#A15]
-+   PK: "PK#A15"
-+   SK: "SK#A15"
-+   _docVersion: 0
-+   _tag: "A"
-+   a: 15
-+   pk: "PK#A15"
-+   sk: "SK#A15"
-
-+ [PK#A16 / SK#A16]
-+   PK: "PK#A16"
-+   SK: "SK#A16"
-+   _docVersion: 0
-+   _tag: "A"
-+   a: 16
-+   pk: "PK#A16"
-+   sk: "SK#A16"
-
-+ [PK#A17 / SK#A17]
-+   PK: "PK#A17"
-+   SK: "SK#A17"
-+   _docVersion: 0
-+   _tag: "A"
-+   a: 17
-+   pk: "PK#A17"
-+   sk: "SK#A17"
-
-+ [PK#A18 / SK#A18]
-+   PK: "PK#A18"
-+   SK: "SK#A18"
-+   _docVersion: 0
-+   _tag: "A"
-+   a: 18
-+   pk: "PK#A18"
-+   sk: "SK#A18"
-
-+ [PK#A19 / SK#A19]
-+   PK: "PK#A19"
-+   SK: "SK#A19"
-+   _docVersion: 0
-+   _tag: "A"
-+   a: 19
-+   pk: "PK#A19"
-+   sk: "SK#A19"
-
-+ [PK#A2 / SK#A2]
-+   PK: "PK#A2"
-+   SK: "SK#A2"
-+   _docVersion: 0
-+   _tag: "A"
-+   a: 2
-+   pk: "PK#A2"
-+   sk: "SK#A2"
-
-+ [PK#A20 / SK#A20]
-+   PK: "PK#A20"
-+   SK: "SK#A20"
-+   _docVersion: 0
-+   _tag: "A"
-+   a: 20
-+   pk: "PK#A20"
-+   sk: "SK#A20"
-
-+ [PK#A21 / SK#A21]
-+   PK: "PK#A21"
-+   SK: "SK#A21"
-+   _docVersion: 0
-+   _tag: "A"
-+   a: 21
-+   pk: "PK#A21"
-+   sk: "SK#A21"
-
-+ [PK#A22 / SK#A22]
-+   PK: "PK#A22"
-+   SK: "SK#A22"
-+   _docVersion: 0
-+   _tag: "A"
-+   a: 22
-+   pk: "PK#A22"
-+   sk: "SK#A22"
-
-+ [PK#A23 / SK#A23]
-+   PK: "PK#A23"
-+   SK: "SK#A23"
-+   _docVersion: 0
-+   _tag: "A"
-+   a: 23
-+   pk: "PK#A23"
-+   sk: "SK#A23"
-
-+ [PK#A24 / SK#A24]
-+   PK: "PK#A24"
-+   SK: "SK#A24"
-+   _docVersion: 0
-+   _tag: "A"
-+   a: 24
-+   pk: "PK#A24"
-+   sk: "SK#A24"
-
-+ [PK#A25 / SK#A25]
-+   PK: "PK#A25"
-+   SK: "SK#A25"
-+   _docVersion: 0
-+   _tag: "A"
-+   a: 25
-+   pk: "PK#A25"
-+   sk: "SK#A25"
-
-+ [PK#A26 / SK#A26]
-+   PK: "PK#A26"
-+   SK: "SK#A26"
-+   _docVersion: 0
-+   _tag: "A"
-+   a: 26
-+   pk: "PK#A26"
-+   sk: "SK#A26"
-
-+ [PK#A27 / SK#A27]
-+   PK: "PK#A27"
-+   SK: "SK#A27"
-+   _docVersion: 0
-+   _tag: "A"
-+   a: 27
-+   pk: "PK#A27"
-+   sk: "SK#A27"
-
-+ [PK#A28 / SK#A28]
-+   PK: "PK#A28"
-+   SK: "SK#A28"
-+   _docVersion: 0
-+   _tag: "A"
-+   a: 28
-+   pk: "PK#A28"
-+   sk: "SK#A28"
-
-+ [PK#A29 / SK#A29]
-+   PK: "PK#A29"
-+   SK: "SK#A29"
-+   _docVersion: 0
-+   _tag: "A"
-+   a: 29
-+   pk: "PK#A29"
-+   sk: "SK#A29"
-
-+ [PK#A3 / SK#A3]
-+   PK: "PK#A3"
-+   SK: "SK#A3"
-+   _docVersion: 0
-+   _tag: "A"
-+   a: 3
-+   pk: "PK#A3"
-+   sk: "SK#A3"
-
-+ [PK#A30 / SK#A30]
-+   PK: "PK#A30"
-+   SK: "SK#A30"
-+   _docVersion: 0
-+   _tag: "A"
-+   a: 30
-+   pk: "PK#A30"
-+   sk: "SK#A30"
-
-+ [PK#A31 / SK#A31]
-+   PK: "PK#A31"
-+   SK: "SK#A31"
-+   _docVersion: 0
-+   _tag: "A"
-+   a: 31
-+   pk: "PK#A31"
-+   sk: "SK#A31"
-
-+ [PK#A32 / SK#A32]
-+   PK: "PK#A32"
-+   SK: "SK#A32"
-+   _docVersion: 0
-+   _tag: "A"
-+   a: 32
-+   pk: "PK#A32"
-+   sk: "SK#A32"
-
-+ [PK#A33 / SK#A33]
-+   PK: "PK#A33"
-+   SK: "SK#A33"
-+   _docVersion: 0
-+   _tag: "A"
-+   a: 33
-+   pk: "PK#A33"
-+   sk: "SK#A33"
-
-+ [PK#A34 / SK#A34]
-+   PK: "PK#A34"
-+   SK: "SK#A34"
-+   _docVersion: 0
-+   _tag: "A"
-+   a: 34
-+   pk: "PK#A34"
-+   sk: "SK#A34"
-
-+ [PK#A35 / SK#A35]
-+   PK: "PK#A35"
-+   SK: "SK#A35"
-+   _docVersion: 0
-+   _tag: "A"
-+   a: 35
-+   pk: "PK#A35"
-+   sk: "SK#A35"
-
-+ [PK#A36 / SK#A36]
-+   PK: "PK#A36"
-+   SK: "SK#A36"
-+   _docVersion: 0
-+   _tag: "A"
-+   a: 36
-+   pk: "PK#A36"
-+   sk: "SK#A36"
-
-+ [PK#A37 / SK#A37]
-+   PK: "PK#A37"
-+   SK: "SK#A37"
-+   _docVersion: 0
-+   _tag: "A"
-+   a: 37
-+   pk: "PK#A37"
-+   sk: "SK#A37"
-
-+ [PK#A38 / SK#A38]
-+   PK: "PK#A38"
-+   SK: "SK#A38"
-+   _docVersion: 0
-+   _tag: "A"
-+   a: 38
-+   pk: "PK#A38"
-+   sk: "SK#A38"
-
-+ [PK#A39 / SK#A39]
-+   PK: "PK#A39"
-+   SK: "SK#A39"
-+   _docVersion: 0
-+   _tag: "A"
-+   a: 39
-+   pk: "PK#A39"
-+   sk: "SK#A39"
-
-+ [PK#A4 / SK#A4]
-+   PK: "PK#A4"
-+   SK: "SK#A4"
-+   _docVersion: 0
-+   _tag: "A"
-+   a: 4
-+   pk: "PK#A4"
-+   sk: "SK#A4"
-
-+ [PK#A40 / SK#A40]
-+   PK: "PK#A40"
-+   SK: "SK#A40"
-+   _docVersion: 0
-+   _tag: "A"
-+   a: 40
-+   pk: "PK#A40"
-+   sk: "SK#A40"
-
-+ [PK#A41 / SK#A41]
-+   PK: "PK#A41"
-+   SK: "SK#A41"
-+   _docVersion: 0
-+   _tag: "A"
-+   a: 41
-+   pk: "PK#A41"
-+   sk: "SK#A41"
-
-+ [PK#A42 / SK#A42]
-+   PK: "PK#A42"
-+   SK: "SK#A42"
-+   _docVersion: 0
-+   _tag: "A"
-+   a: 42
-+   pk: "PK#A42"
-+   sk: "SK#A42"
-
-+ [PK#A43 / SK#A43]
-+   PK: "PK#A43"
-+   SK: "SK#A43"
-+   _docVersion: 0
-+   _tag: "A"
-+   a: 43
-+   pk: "PK#A43"
-+   sk: "SK#A43"
-
-+ [PK#A44 / SK#A44]
-+   PK: "PK#A44"
-+   SK: "SK#A44"
-+   _docVersion: 0
-+   _tag: "A"
-+   a: 44
-+   pk: "PK#A44"
-+   sk: "SK#A44"
-
-+ [PK#A45 / SK#A45]
-+   PK: "PK#A45"
-+   SK: "SK#A45"
-+   _docVersion: 0
-+   _tag: "A"
-+   a: 45
-+   pk: "PK#A45"
-+   sk: "SK#A45"
-
-+ [PK#A46 / SK#A46]
-+   PK: "PK#A46"
-+   SK: "SK#A46"
-+   _docVersion: 0
-+   _tag: "A"
-+   a: 46
-+   pk: "PK#A46"
-+   sk: "SK#A46"
-
-+ [PK#A47 / SK#A47]
-+   PK: "PK#A47"
-+   SK: "SK#A47"
-+   _docVersion: 0
-+   _tag: "A"
-+   a: 47
-+   pk: "PK#A47"
-+   sk: "SK#A47"
-
-+ [PK#A48 / SK#A48]
-+   PK: "PK#A48"
-+   SK: "SK#A48"
-+   _docVersion: 0
-+   _tag: "A"
-+   a: 48
-+   pk: "PK#A48"
-+   sk: "SK#A48"
-
-+ [PK#A49 / SK#A49]
-+   PK: "PK#A49"
-+   SK: "SK#A49"
-+   _docVersion: 0
-+   _tag: "A"
-+   a: 49
-+   pk: "PK#A49"
-+   sk: "SK#A49"
-
-+ [PK#A5 / SK#A5]
-+   PK: "PK#A5"
-+   SK: "SK#A5"
-+   _docVersion: 0
-+   _tag: "A"
-+   a: 5
-+   pk: "PK#A5"
-+   sk: "SK#A5"
-
-+ [PK#A50 / SK#A50]
-+   PK: "PK#A50"
-+   SK: "SK#A50"
-+   _docVersion: 0
-+   _tag: "A"
-+   a: 50
-+   pk: "PK#A50"
-+   sk: "SK#A50"
-
-+ [PK#A51 / SK#A51]
-+   PK: "PK#A51"
-+   SK: "SK#A51"
-+   _docVersion: 0
-+   _tag: "A"
-+   a: 51
-+   pk: "PK#A51"
-+   sk: "SK#A51"
-
-+ [PK#A52 / SK#A52]
-+   PK: "PK#A52"
-+   SK: "SK#A52"
-+   _docVersion: 0
-+   _tag: "A"
-+   a: 52
-+   pk: "PK#A52"
-+   sk: "SK#A52"
-
-+ [PK#A53 / SK#A53]
-+   PK: "PK#A53"
-+   SK: "SK#A53"
-+   _docVersion: 0
-+   _tag: "A"
-+   a: 53
-+   pk: "PK#A53"
-+   sk: "SK#A53"
-
-+ [PK#A54 / SK#A54]
-+   PK: "PK#A54"
-+   SK: "SK#A54"
-+   _docVersion: 0
-+   _tag: "A"
-+   a: 54
-+   pk: "PK#A54"
-+   sk: "SK#A54"
-
-+ [PK#A55 / SK#A55]
-+   PK: "PK#A55"
-+   SK: "SK#A55"
-+   _docVersion: 0
-+   _tag: "A"
-+   a: 55
-+   pk: "PK#A55"
-+   sk: "SK#A55"
-
-+ [PK#A56 / SK#A56]
-+   PK: "PK#A56"
-+   SK: "SK#A56"
-+   _docVersion: 0
-+   _tag: "A"
-+   a: 56
-+   pk: "PK#A56"
-+   sk: "SK#A56"
-
-+ [PK#A57 / SK#A57]
-+   PK: "PK#A57"
-+   SK: "SK#A57"
-+   _docVersion: 0
-+   _tag: "A"
-+   a: 57
-+   pk: "PK#A57"
-+   sk: "SK#A57"
-
-+ [PK#A58 / SK#A58]
-+   PK: "PK#A58"
-+   SK: "SK#A58"
-+   _docVersion: 0
-+   _tag: "A"
-+   a: 58
-+   pk: "PK#A58"
-+   sk: "SK#A58"
-
-+ [PK#A59 / SK#A59]
-+   PK: "PK#A59"
-+   SK: "SK#A59"
-+   _docVersion: 0
-+   _tag: "A"
-+   a: 59
-+   pk: "PK#A59"
-+   sk: "SK#A59"
-
-+ [PK#A6 / SK#A6]
-+   PK: "PK#A6"
-+   SK: "SK#A6"
-+   _docVersion: 0
-+   _tag: "A"
-+   a: 6
-+   pk: "PK#A6"
-+   sk: "SK#A6"
-
-+ [PK#A60 / SK#A60]
-+   PK: "PK#A60"
-+   SK: "SK#A60"
-+   _docVersion: 0
-+   _tag: "A"
-+   a: 60
-+   pk: "PK#A60"
-+   sk: "SK#A60"
-
-+ [PK#A61 / SK#A61]
-+   PK: "PK#A61"
-+   SK: "SK#A61"
-+   _docVersion: 0
-+   _tag: "A"
-+   a: 61
-+   pk: "PK#A61"
-+   sk: "SK#A61"
-
-+ [PK#A62 / SK#A62]
-+   PK: "PK#A62"
-+   SK: "SK#A62"
-+   _docVersion: 0
-+   _tag: "A"
-+   a: 62
-+   pk: "PK#A62"
-+   sk: "SK#A62"
-
-+ [PK#A63 / SK#A63]
-+   PK: "PK#A63"
-+   SK: "SK#A63"
-+   _docVersion: 0
-+   _tag: "A"
-+   a: 63
-+   pk: "PK#A63"
-+   sk: "SK#A63"
-
-+ [PK#A64 / SK#A64]
-+   PK: "PK#A64"
-+   SK: "SK#A64"
-+   _docVersion: 0
-+   _tag: "A"
-+   a: 64
-+   pk: "PK#A64"
-+   sk: "SK#A64"
-
-+ [PK#A65 / SK#A65]
-+   PK: "PK#A65"
-+   SK: "SK#A65"
-+   _docVersion: 0
-+   _tag: "A"
-+   a: 65
-+   pk: "PK#A65"
-+   sk: "SK#A65"
-
-+ [PK#A66 / SK#A66]
-+   PK: "PK#A66"
-+   SK: "SK#A66"
-+   _docVersion: 0
-+   _tag: "A"
-+   a: 66
-+   pk: "PK#A66"
-+   sk: "SK#A66"
-
-+ [PK#A67 / SK#A67]
-+   PK: "PK#A67"
-+   SK: "SK#A67"
-+   _docVersion: 0
-+   _tag: "A"
-+   a: 67
-+   pk: "PK#A67"
-+   sk: "SK#A67"
-
-+ [PK#A68 / SK#A68]
-+   PK: "PK#A68"
-+   SK: "SK#A68"
-+   _docVersion: 0
-+   _tag: "A"
-+   a: 68
-+   pk: "PK#A68"
-+   sk: "SK#A68"
-
-+ [PK#A69 / SK#A69]
-+   PK: "PK#A69"
-+   SK: "SK#A69"
-+   _docVersion: 0
-+   _tag: "A"
-+   a: 69
-+   pk: "PK#A69"
-+   sk: "SK#A69"
-
-+ [PK#A7 / SK#A7]
-+   PK: "PK#A7"
-+   SK: "SK#A7"
-+   _docVersion: 0
-+   _tag: "A"
-+   a: 7
-+   pk: "PK#A7"
-+   sk: "SK#A7"
-
-+ [PK#A70 / SK#A70]
-+   PK: "PK#A70"
-+   SK: "SK#A70"
-+   _docVersion: 0
-+   _tag: "A"
-+   a: 70
-+   pk: "PK#A70"
-+   sk: "SK#A70"
-
-+ [PK#A71 / SK#A71]
-+   PK: "PK#A71"
-+   SK: "SK#A71"
-+   _docVersion: 0
-+   _tag: "A"
-+   a: 71
-+   pk: "PK#A71"
-+   sk: "SK#A71"
-
-+ [PK#A72 / SK#A72]
-+   PK: "PK#A72"
-+   SK: "SK#A72"
-+   _docVersion: 0
-+   _tag: "A"
-+   a: 72
-+   pk: "PK#A72"
-+   sk: "SK#A72"
-
-+ [PK#A73 / SK#A73]
-+   PK: "PK#A73"
-+   SK: "SK#A73"
-+   _docVersion: 0
-+   _tag: "A"
-+   a: 73
-+   pk: "PK#A73"
-+   sk: "SK#A73"
-
-+ [PK#A74 / SK#A74]
-+   PK: "PK#A74"
-+   SK: "SK#A74"
-+   _docVersion: 0
-+   _tag: "A"
-+   a: 74
-+   pk: "PK#A74"
-+   sk: "SK#A74"
-
-+ [PK#A75 / SK#A75]
-+   PK: "PK#A75"
-+   SK: "SK#A75"
-+   _docVersion: 0
-+   _tag: "A"
-+   a: 75
-+   pk: "PK#A75"
-+   sk: "SK#A75"
-
-+ [PK#A76 / SK#A76]
-+   PK: "PK#A76"
-+   SK: "SK#A76"
-+   _docVersion: 0
-+   _tag: "A"
-+   a: 76
-+   pk: "PK#A76"
-+   sk: "SK#A76"
-
-+ [PK#A77 / SK#A77]
-+   PK: "PK#A77"
-+   SK: "SK#A77"
-+   _docVersion: 0
-+   _tag: "A"
-+   a: 77
-+   pk: "PK#A77"
-+   sk: "SK#A77"
-
-+ [PK#A78 / SK#A78]
-+   PK: "PK#A78"
-+   SK: "SK#A78"
-+   _docVersion: 0
-+   _tag: "A"
-+   a: 78
-+   pk: "PK#A78"
-+   sk: "SK#A78"
-
-+ [PK#A79 / SK#A79]
-+   PK: "PK#A79"
-+   SK: "SK#A79"
-+   _docVersion: 0
-+   _tag: "A"
-+   a: 79
-+   pk: "PK#A79"
-+   sk: "SK#A79"
-
-+ [PK#A8 / SK#A8]
-+   PK: "PK#A8"
-+   SK: "SK#A8"
-+   _docVersion: 0
-+   _tag: "A"
-+   a: 8
-+   pk: "PK#A8"
-+   sk: "SK#A8"
-
-+ [PK#A80 / SK#A80]
-+   PK: "PK#A80"
-+   SK: "SK#A80"
-+   _docVersion: 0
-+   _tag: "A"
-+   a: 80
-+   pk: "PK#A80"
-+   sk: "SK#A80"
-
-+ [PK#A81 / SK#A81]
-+   PK: "PK#A81"
-+   SK: "SK#A81"
-+   _docVersion: 0
-+   _tag: "A"
-+   a: 81
-+   pk: "PK#A81"
-+   sk: "SK#A81"
-
-+ [PK#A82 / SK#A82]
-+   PK: "PK#A82"
-+   SK: "SK#A82"
-+   _docVersion: 0
-+   _tag: "A"
-+   a: 82
-+   pk: "PK#A82"
-+   sk: "SK#A82"
-
-+ [PK#A83 / SK#A83]
-+   PK: "PK#A83"
-+   SK: "SK#A83"
-+   _docVersion: 0
-+   _tag: "A"
-+   a: 83
-+   pk: "PK#A83"
-+   sk: "SK#A83"
-
-+ [PK#A84 / SK#A84]
-+   PK: "PK#A84"
-+   SK: "SK#A84"
-+   _docVersion: 0
-+   _tag: "A"
-+   a: 84
-+   pk: "PK#A84"
-+   sk: "SK#A84"
-
-+ [PK#A85 / SK#A85]
-+   PK: "PK#A85"
-+   SK: "SK#A85"
-+   _docVersion: 0
-+   _tag: "A"
-+   a: 85
-+   pk: "PK#A85"
-+   sk: "SK#A85"
-
-+ [PK#A86 / SK#A86]
-+   PK: "PK#A86"
-+   SK: "SK#A86"
-+   _docVersion: 0
-+   _tag: "A"
-+   a: 86
-+   pk: "PK#A86"
-+   sk: "SK#A86"
-
-+ [PK#A87 / SK#A87]
-+   PK: "PK#A87"
-+   SK: "SK#A87"
-+   _docVersion: 0
-+   _tag: "A"
-+   a: 87
-+   pk: "PK#A87"
-+   sk: "SK#A87"
-
-+ [PK#A88 / SK#A88]
-+   PK: "PK#A88"
-+   SK: "SK#A88"
-+   _docVersion: 0
-+   _tag: "A"
-+   a: 88
-+   pk: "PK#A88"
-+   sk: "SK#A88"
-
-+ [PK#A89 / SK#A89]
-+   PK: "PK#A89"
-+   SK: "SK#A89"
-+   _docVersion: 0
-+   _tag: "A"
-+   a: 89
-+   pk: "PK#A89"
-+   sk: "SK#A89"
-
-+ [PK#A9 / SK#A9]
-+   PK: "PK#A9"
-+   SK: "SK#A9"
-+   _docVersion: 0
-+   _tag: "A"
-+   a: 9
-+   pk: "PK#A9"
-+   sk: "SK#A9"
-
-+ [PK#A90 / SK#A90]
-+   PK: "PK#A90"
-+   SK: "SK#A90"
-+   _docVersion: 0
-+   _tag: "A"
-+   a: 90
-+   pk: "PK#A90"
-+   sk: "SK#A90"
-
-+ [PK#A91 / SK#A91]
-+   PK: "PK#A91"
-+   SK: "SK#A91"
-+   _docVersion: 0
-+   _tag: "A"
-+   a: 91
-+   pk: "PK#A91"
-+   sk: "SK#A91"
-
-+ [PK#A92 / SK#A92]
-+   PK: "PK#A92"
-+   SK: "SK#A92"
-+   _docVersion: 0
-+   _tag: "A"
-+   a: 92
-+   pk: "PK#A92"
-+   sk: "SK#A92"
-
-+ [PK#A93 / SK#A93]
-+   PK: "PK#A93"
-+   SK: "SK#A93"
-+   _docVersion: 0
-+   _tag: "A"
-+   a: 93
-+   pk: "PK#A93"
-+   sk: "SK#A93"
-
-+ [PK#A94 / SK#A94]
-+   PK: "PK#A94"
-+   SK: "SK#A94"
-+   _docVersion: 0
-+   _tag: "A"
-+   a: 94
-+   pk: "PK#A94"
-+   sk: "SK#A94"
-
-+ [PK#A95 / SK#A95]
-+   PK: "PK#A95"
-+   SK: "SK#A95"
-+   _docVersion: 0
-+   _tag: "A"
-+   a: 95
-+   pk: "PK#A95"
-+   sk: "SK#A95"
-
-+ [PK#A96 / SK#A96]
-+   PK: "PK#A96"
-+   SK: "SK#A96"
-+   _docVersion: 0
-+   _tag: "A"
-+   a: 96
-+   pk: "PK#A96"
-+   sk: "SK#A96"
-
-+ [PK#A97 / SK#A97]
-+   PK: "PK#A97"
-+   SK: "SK#A97"
-+   _docVersion: 0
-+   _tag: "A"
-+   a: 97
-+   pk: "PK#A97"
-+   sk: "SK#A97"
-
-+ [PK#A98 / SK#A98]
-+   PK: "PK#A98"
-+   SK: "SK#A98"
-+   _docVersion: 0
-+   _tag: "A"
-+   a: 98
-+   pk: "PK#A98"
-+   sk: "SK#A98"
-
-+ [PK#A99 / SK#A99]
-+   PK: "PK#A99"
-+   SK: "SK#A99"
-+   _docVersion: 0
-+   _tag: "A"
-+   a: 99
-+   pk: "PK#A99"
-+   sk: "SK#A99"
-
-+ [PK#UPDATE / SK#UPDATE]
-+   PK: "PK#UPDATE"
-+   SK: "SK#UPDATE"
-+   _docVersion: 1
-+   _tag: "B"
-+   b: "baz"
-+   pk: "PK#UPDATE"
-+   sk: "SK#UPDATE"
-
-+ [PK4 / PK4]
-+   PK: "PK4"
-+   SK: "PK4"
-+   _docVersion: 0
-+   _tag: "A"
-+   a: 4
-+   pk: "PK4"
-+   sk: "PK4"
-
-+ [PK5 / PK5]
-+   PK: "PK5"
-+   SK: "PK5"
-+   _docVersion: 0
-+   _tag: "A"
-+   a: 5
-+   pk: "PK5"
-+   sk: "PK5"
-
-+ [PK6 / SK6]
-+   PK: "PK6"
-+   SK: "SK6"
-+   _docVersion: 0
-+   _tag: "B"
-+   b: "baz"
-+   pk: "PK6"
-+   sk: "SK6"
-`)
+        [PK#1 / SK#1]
+            PK: "PK#1"
+            SK: "SK#1"
+            _docVersion: 0
+            _tag: "A"
+        -   a: 1
+        +   a: -1
+            pk: "PK#1"
+            sk: "SK#1"
+
+        - [PK#2 / SK#2]
+        -   PK: "PK#2"
+        -   SK: "SK#2"
+        -   _docVersion: 0
+        -   _tag: "A"
+        -   a: 2
+        -   pk: "PK#2"
+        -   sk: "SK#2"
+
+        - [PK#3 / SK#3]
+        -   PK: "PK#3"
+        -   SK: "SK#3"
+        -   _docVersion: 0
+        -   _tag: "B"
+        -   b: "bar"
+        -   pk: "PK#3"
+        -   sk: "SK#3"
+
+        + [PK#A0 / SK#A0]
+        +   PK: "PK#A0"
+        +   SK: "SK#A0"
+        +   _docVersion: 0
+        +   _tag: "A"
+        +   a: 0
+        +   pk: "PK#A0"
+        +   sk: "SK#A0"
+
+        + [PK#A1 / SK#A1]
+        +   PK: "PK#A1"
+        +   SK: "SK#A1"
+        +   _docVersion: 0
+        +   _tag: "A"
+        +   a: 1
+        +   pk: "PK#A1"
+        +   sk: "SK#A1"
+
+        + [PK#A10 / SK#A10]
+        +   PK: "PK#A10"
+        +   SK: "SK#A10"
+        +   _docVersion: 0
+        +   _tag: "A"
+        +   a: 10
+        +   pk: "PK#A10"
+        +   sk: "SK#A10"
+
+        + [PK#A11 / SK#A11]
+        +   PK: "PK#A11"
+        +   SK: "SK#A11"
+        +   _docVersion: 0
+        +   _tag: "A"
+        +   a: 11
+        +   pk: "PK#A11"
+        +   sk: "SK#A11"
+
+        + [PK#A12 / SK#A12]
+        +   PK: "PK#A12"
+        +   SK: "SK#A12"
+        +   _docVersion: 0
+        +   _tag: "A"
+        +   a: 12
+        +   pk: "PK#A12"
+        +   sk: "SK#A12"
+
+        + [PK#A13 / SK#A13]
+        +   PK: "PK#A13"
+        +   SK: "SK#A13"
+        +   _docVersion: 0
+        +   _tag: "A"
+        +   a: 13
+        +   pk: "PK#A13"
+        +   sk: "SK#A13"
+
+        + [PK#A14 / SK#A14]
+        +   PK: "PK#A14"
+        +   SK: "SK#A14"
+        +   _docVersion: 0
+        +   _tag: "A"
+        +   a: 14
+        +   pk: "PK#A14"
+        +   sk: "SK#A14"
+
+        + [PK#A15 / SK#A15]
+        +   PK: "PK#A15"
+        +   SK: "SK#A15"
+        +   _docVersion: 0
+        +   _tag: "A"
+        +   a: 15
+        +   pk: "PK#A15"
+        +   sk: "SK#A15"
+
+        + [PK#A16 / SK#A16]
+        +   PK: "PK#A16"
+        +   SK: "SK#A16"
+        +   _docVersion: 0
+        +   _tag: "A"
+        +   a: 16
+        +   pk: "PK#A16"
+        +   sk: "SK#A16"
+
+        + [PK#A17 / SK#A17]
+        +   PK: "PK#A17"
+        +   SK: "SK#A17"
+        +   _docVersion: 0
+        +   _tag: "A"
+        +   a: 17
+        +   pk: "PK#A17"
+        +   sk: "SK#A17"
+
+        + [PK#A18 / SK#A18]
+        +   PK: "PK#A18"
+        +   SK: "SK#A18"
+        +   _docVersion: 0
+        +   _tag: "A"
+        +   a: 18
+        +   pk: "PK#A18"
+        +   sk: "SK#A18"
+
+        + [PK#A19 / SK#A19]
+        +   PK: "PK#A19"
+        +   SK: "SK#A19"
+        +   _docVersion: 0
+        +   _tag: "A"
+        +   a: 19
+        +   pk: "PK#A19"
+        +   sk: "SK#A19"
+
+        + [PK#A2 / SK#A2]
+        +   PK: "PK#A2"
+        +   SK: "SK#A2"
+        +   _docVersion: 0
+        +   _tag: "A"
+        +   a: 2
+        +   pk: "PK#A2"
+        +   sk: "SK#A2"
+
+        + [PK#A20 / SK#A20]
+        +   PK: "PK#A20"
+        +   SK: "SK#A20"
+        +   _docVersion: 0
+        +   _tag: "A"
+        +   a: 20
+        +   pk: "PK#A20"
+        +   sk: "SK#A20"
+
+        + [PK#A21 / SK#A21]
+        +   PK: "PK#A21"
+        +   SK: "SK#A21"
+        +   _docVersion: 0
+        +   _tag: "A"
+        +   a: 21
+        +   pk: "PK#A21"
+        +   sk: "SK#A21"
+
+        + [PK#A22 / SK#A22]
+        +   PK: "PK#A22"
+        +   SK: "SK#A22"
+        +   _docVersion: 0
+        +   _tag: "A"
+        +   a: 22
+        +   pk: "PK#A22"
+        +   sk: "SK#A22"
+
+        + [PK#A23 / SK#A23]
+        +   PK: "PK#A23"
+        +   SK: "SK#A23"
+        +   _docVersion: 0
+        +   _tag: "A"
+        +   a: 23
+        +   pk: "PK#A23"
+        +   sk: "SK#A23"
+
+        + [PK#A24 / SK#A24]
+        +   PK: "PK#A24"
+        +   SK: "SK#A24"
+        +   _docVersion: 0
+        +   _tag: "A"
+        +   a: 24
+        +   pk: "PK#A24"
+        +   sk: "SK#A24"
+
+        + [PK#A25 / SK#A25]
+        +   PK: "PK#A25"
+        +   SK: "SK#A25"
+        +   _docVersion: 0
+        +   _tag: "A"
+        +   a: 25
+        +   pk: "PK#A25"
+        +   sk: "SK#A25"
+
+        + [PK#A26 / SK#A26]
+        +   PK: "PK#A26"
+        +   SK: "SK#A26"
+        +   _docVersion: 0
+        +   _tag: "A"
+        +   a: 26
+        +   pk: "PK#A26"
+        +   sk: "SK#A26"
+
+        + [PK#A27 / SK#A27]
+        +   PK: "PK#A27"
+        +   SK: "SK#A27"
+        +   _docVersion: 0
+        +   _tag: "A"
+        +   a: 27
+        +   pk: "PK#A27"
+        +   sk: "SK#A27"
+
+        + [PK#A28 / SK#A28]
+        +   PK: "PK#A28"
+        +   SK: "SK#A28"
+        +   _docVersion: 0
+        +   _tag: "A"
+        +   a: 28
+        +   pk: "PK#A28"
+        +   sk: "SK#A28"
+
+        + [PK#A29 / SK#A29]
+        +   PK: "PK#A29"
+        +   SK: "SK#A29"
+        +   _docVersion: 0
+        +   _tag: "A"
+        +   a: 29
+        +   pk: "PK#A29"
+        +   sk: "SK#A29"
+
+        + [PK#A3 / SK#A3]
+        +   PK: "PK#A3"
+        +   SK: "SK#A3"
+        +   _docVersion: 0
+        +   _tag: "A"
+        +   a: 3
+        +   pk: "PK#A3"
+        +   sk: "SK#A3"
+
+        + [PK#A30 / SK#A30]
+        +   PK: "PK#A30"
+        +   SK: "SK#A30"
+        +   _docVersion: 0
+        +   _tag: "A"
+        +   a: 30
+        +   pk: "PK#A30"
+        +   sk: "SK#A30"
+
+        + [PK#A31 / SK#A31]
+        +   PK: "PK#A31"
+        +   SK: "SK#A31"
+        +   _docVersion: 0
+        +   _tag: "A"
+        +   a: 31
+        +   pk: "PK#A31"
+        +   sk: "SK#A31"
+
+        + [PK#A32 / SK#A32]
+        +   PK: "PK#A32"
+        +   SK: "SK#A32"
+        +   _docVersion: 0
+        +   _tag: "A"
+        +   a: 32
+        +   pk: "PK#A32"
+        +   sk: "SK#A32"
+
+        + [PK#A33 / SK#A33]
+        +   PK: "PK#A33"
+        +   SK: "SK#A33"
+        +   _docVersion: 0
+        +   _tag: "A"
+        +   a: 33
+        +   pk: "PK#A33"
+        +   sk: "SK#A33"
+
+        + [PK#A34 / SK#A34]
+        +   PK: "PK#A34"
+        +   SK: "SK#A34"
+        +   _docVersion: 0
+        +   _tag: "A"
+        +   a: 34
+        +   pk: "PK#A34"
+        +   sk: "SK#A34"
+
+        + [PK#A35 / SK#A35]
+        +   PK: "PK#A35"
+        +   SK: "SK#A35"
+        +   _docVersion: 0
+        +   _tag: "A"
+        +   a: 35
+        +   pk: "PK#A35"
+        +   sk: "SK#A35"
+
+        + [PK#A36 / SK#A36]
+        +   PK: "PK#A36"
+        +   SK: "SK#A36"
+        +   _docVersion: 0
+        +   _tag: "A"
+        +   a: 36
+        +   pk: "PK#A36"
+        +   sk: "SK#A36"
+
+        + [PK#A37 / SK#A37]
+        +   PK: "PK#A37"
+        +   SK: "SK#A37"
+        +   _docVersion: 0
+        +   _tag: "A"
+        +   a: 37
+        +   pk: "PK#A37"
+        +   sk: "SK#A37"
+
+        + [PK#A38 / SK#A38]
+        +   PK: "PK#A38"
+        +   SK: "SK#A38"
+        +   _docVersion: 0
+        +   _tag: "A"
+        +   a: 38
+        +   pk: "PK#A38"
+        +   sk: "SK#A38"
+
+        + [PK#A39 / SK#A39]
+        +   PK: "PK#A39"
+        +   SK: "SK#A39"
+        +   _docVersion: 0
+        +   _tag: "A"
+        +   a: 39
+        +   pk: "PK#A39"
+        +   sk: "SK#A39"
+
+        + [PK#A4 / SK#A4]
+        +   PK: "PK#A4"
+        +   SK: "SK#A4"
+        +   _docVersion: 0
+        +   _tag: "A"
+        +   a: 4
+        +   pk: "PK#A4"
+        +   sk: "SK#A4"
+
+        + [PK#A40 / SK#A40]
+        +   PK: "PK#A40"
+        +   SK: "SK#A40"
+        +   _docVersion: 0
+        +   _tag: "A"
+        +   a: 40
+        +   pk: "PK#A40"
+        +   sk: "SK#A40"
+
+        + [PK#A41 / SK#A41]
+        +   PK: "PK#A41"
+        +   SK: "SK#A41"
+        +   _docVersion: 0
+        +   _tag: "A"
+        +   a: 41
+        +   pk: "PK#A41"
+        +   sk: "SK#A41"
+
+        + [PK#A42 / SK#A42]
+        +   PK: "PK#A42"
+        +   SK: "SK#A42"
+        +   _docVersion: 0
+        +   _tag: "A"
+        +   a: 42
+        +   pk: "PK#A42"
+        +   sk: "SK#A42"
+
+        + [PK#A43 / SK#A43]
+        +   PK: "PK#A43"
+        +   SK: "SK#A43"
+        +   _docVersion: 0
+        +   _tag: "A"
+        +   a: 43
+        +   pk: "PK#A43"
+        +   sk: "SK#A43"
+
+        + [PK#A44 / SK#A44]
+        +   PK: "PK#A44"
+        +   SK: "SK#A44"
+        +   _docVersion: 0
+        +   _tag: "A"
+        +   a: 44
+        +   pk: "PK#A44"
+        +   sk: "SK#A44"
+
+        + [PK#A45 / SK#A45]
+        +   PK: "PK#A45"
+        +   SK: "SK#A45"
+        +   _docVersion: 0
+        +   _tag: "A"
+        +   a: 45
+        +   pk: "PK#A45"
+        +   sk: "SK#A45"
+
+        + [PK#A46 / SK#A46]
+        +   PK: "PK#A46"
+        +   SK: "SK#A46"
+        +   _docVersion: 0
+        +   _tag: "A"
+        +   a: 46
+        +   pk: "PK#A46"
+        +   sk: "SK#A46"
+
+        + [PK#A47 / SK#A47]
+        +   PK: "PK#A47"
+        +   SK: "SK#A47"
+        +   _docVersion: 0
+        +   _tag: "A"
+        +   a: 47
+        +   pk: "PK#A47"
+        +   sk: "SK#A47"
+
+        + [PK#A48 / SK#A48]
+        +   PK: "PK#A48"
+        +   SK: "SK#A48"
+        +   _docVersion: 0
+        +   _tag: "A"
+        +   a: 48
+        +   pk: "PK#A48"
+        +   sk: "SK#A48"
+
+        + [PK#A49 / SK#A49]
+        +   PK: "PK#A49"
+        +   SK: "SK#A49"
+        +   _docVersion: 0
+        +   _tag: "A"
+        +   a: 49
+        +   pk: "PK#A49"
+        +   sk: "SK#A49"
+
+        + [PK#A5 / SK#A5]
+        +   PK: "PK#A5"
+        +   SK: "SK#A5"
+        +   _docVersion: 0
+        +   _tag: "A"
+        +   a: 5
+        +   pk: "PK#A5"
+        +   sk: "SK#A5"
+
+        + [PK#A50 / SK#A50]
+        +   PK: "PK#A50"
+        +   SK: "SK#A50"
+        +   _docVersion: 0
+        +   _tag: "A"
+        +   a: 50
+        +   pk: "PK#A50"
+        +   sk: "SK#A50"
+
+        + [PK#A51 / SK#A51]
+        +   PK: "PK#A51"
+        +   SK: "SK#A51"
+        +   _docVersion: 0
+        +   _tag: "A"
+        +   a: 51
+        +   pk: "PK#A51"
+        +   sk: "SK#A51"
+
+        + [PK#A52 / SK#A52]
+        +   PK: "PK#A52"
+        +   SK: "SK#A52"
+        +   _docVersion: 0
+        +   _tag: "A"
+        +   a: 52
+        +   pk: "PK#A52"
+        +   sk: "SK#A52"
+
+        + [PK#A53 / SK#A53]
+        +   PK: "PK#A53"
+        +   SK: "SK#A53"
+        +   _docVersion: 0
+        +   _tag: "A"
+        +   a: 53
+        +   pk: "PK#A53"
+        +   sk: "SK#A53"
+
+        + [PK#A54 / SK#A54]
+        +   PK: "PK#A54"
+        +   SK: "SK#A54"
+        +   _docVersion: 0
+        +   _tag: "A"
+        +   a: 54
+        +   pk: "PK#A54"
+        +   sk: "SK#A54"
+
+        + [PK#A55 / SK#A55]
+        +   PK: "PK#A55"
+        +   SK: "SK#A55"
+        +   _docVersion: 0
+        +   _tag: "A"
+        +   a: 55
+        +   pk: "PK#A55"
+        +   sk: "SK#A55"
+
+        + [PK#A56 / SK#A56]
+        +   PK: "PK#A56"
+        +   SK: "SK#A56"
+        +   _docVersion: 0
+        +   _tag: "A"
+        +   a: 56
+        +   pk: "PK#A56"
+        +   sk: "SK#A56"
+
+        + [PK#A57 / SK#A57]
+        +   PK: "PK#A57"
+        +   SK: "SK#A57"
+        +   _docVersion: 0
+        +   _tag: "A"
+        +   a: 57
+        +   pk: "PK#A57"
+        +   sk: "SK#A57"
+
+        + [PK#A58 / SK#A58]
+        +   PK: "PK#A58"
+        +   SK: "SK#A58"
+        +   _docVersion: 0
+        +   _tag: "A"
+        +   a: 58
+        +   pk: "PK#A58"
+        +   sk: "SK#A58"
+
+        + [PK#A59 / SK#A59]
+        +   PK: "PK#A59"
+        +   SK: "SK#A59"
+        +   _docVersion: 0
+        +   _tag: "A"
+        +   a: 59
+        +   pk: "PK#A59"
+        +   sk: "SK#A59"
+
+        + [PK#A6 / SK#A6]
+        +   PK: "PK#A6"
+        +   SK: "SK#A6"
+        +   _docVersion: 0
+        +   _tag: "A"
+        +   a: 6
+        +   pk: "PK#A6"
+        +   sk: "SK#A6"
+
+        + [PK#A60 / SK#A60]
+        +   PK: "PK#A60"
+        +   SK: "SK#A60"
+        +   _docVersion: 0
+        +   _tag: "A"
+        +   a: 60
+        +   pk: "PK#A60"
+        +   sk: "SK#A60"
+
+        + [PK#A61 / SK#A61]
+        +   PK: "PK#A61"
+        +   SK: "SK#A61"
+        +   _docVersion: 0
+        +   _tag: "A"
+        +   a: 61
+        +   pk: "PK#A61"
+        +   sk: "SK#A61"
+
+        + [PK#A62 / SK#A62]
+        +   PK: "PK#A62"
+        +   SK: "SK#A62"
+        +   _docVersion: 0
+        +   _tag: "A"
+        +   a: 62
+        +   pk: "PK#A62"
+        +   sk: "SK#A62"
+
+        + [PK#A63 / SK#A63]
+        +   PK: "PK#A63"
+        +   SK: "SK#A63"
+        +   _docVersion: 0
+        +   _tag: "A"
+        +   a: 63
+        +   pk: "PK#A63"
+        +   sk: "SK#A63"
+
+        + [PK#A64 / SK#A64]
+        +   PK: "PK#A64"
+        +   SK: "SK#A64"
+        +   _docVersion: 0
+        +   _tag: "A"
+        +   a: 64
+        +   pk: "PK#A64"
+        +   sk: "SK#A64"
+
+        + [PK#A65 / SK#A65]
+        +   PK: "PK#A65"
+        +   SK: "SK#A65"
+        +   _docVersion: 0
+        +   _tag: "A"
+        +   a: 65
+        +   pk: "PK#A65"
+        +   sk: "SK#A65"
+
+        + [PK#A66 / SK#A66]
+        +   PK: "PK#A66"
+        +   SK: "SK#A66"
+        +   _docVersion: 0
+        +   _tag: "A"
+        +   a: 66
+        +   pk: "PK#A66"
+        +   sk: "SK#A66"
+
+        + [PK#A67 / SK#A67]
+        +   PK: "PK#A67"
+        +   SK: "SK#A67"
+        +   _docVersion: 0
+        +   _tag: "A"
+        +   a: 67
+        +   pk: "PK#A67"
+        +   sk: "SK#A67"
+
+        + [PK#A68 / SK#A68]
+        +   PK: "PK#A68"
+        +   SK: "SK#A68"
+        +   _docVersion: 0
+        +   _tag: "A"
+        +   a: 68
+        +   pk: "PK#A68"
+        +   sk: "SK#A68"
+
+        + [PK#A69 / SK#A69]
+        +   PK: "PK#A69"
+        +   SK: "SK#A69"
+        +   _docVersion: 0
+        +   _tag: "A"
+        +   a: 69
+        +   pk: "PK#A69"
+        +   sk: "SK#A69"
+
+        + [PK#A7 / SK#A7]
+        +   PK: "PK#A7"
+        +   SK: "SK#A7"
+        +   _docVersion: 0
+        +   _tag: "A"
+        +   a: 7
+        +   pk: "PK#A7"
+        +   sk: "SK#A7"
+
+        + [PK#A70 / SK#A70]
+        +   PK: "PK#A70"
+        +   SK: "SK#A70"
+        +   _docVersion: 0
+        +   _tag: "A"
+        +   a: 70
+        +   pk: "PK#A70"
+        +   sk: "SK#A70"
+
+        + [PK#A71 / SK#A71]
+        +   PK: "PK#A71"
+        +   SK: "SK#A71"
+        +   _docVersion: 0
+        +   _tag: "A"
+        +   a: 71
+        +   pk: "PK#A71"
+        +   sk: "SK#A71"
+
+        + [PK#A72 / SK#A72]
+        +   PK: "PK#A72"
+        +   SK: "SK#A72"
+        +   _docVersion: 0
+        +   _tag: "A"
+        +   a: 72
+        +   pk: "PK#A72"
+        +   sk: "SK#A72"
+
+        + [PK#A73 / SK#A73]
+        +   PK: "PK#A73"
+        +   SK: "SK#A73"
+        +   _docVersion: 0
+        +   _tag: "A"
+        +   a: 73
+        +   pk: "PK#A73"
+        +   sk: "SK#A73"
+
+        + [PK#A74 / SK#A74]
+        +   PK: "PK#A74"
+        +   SK: "SK#A74"
+        +   _docVersion: 0
+        +   _tag: "A"
+        +   a: 74
+        +   pk: "PK#A74"
+        +   sk: "SK#A74"
+
+        + [PK#A75 / SK#A75]
+        +   PK: "PK#A75"
+        +   SK: "SK#A75"
+        +   _docVersion: 0
+        +   _tag: "A"
+        +   a: 75
+        +   pk: "PK#A75"
+        +   sk: "SK#A75"
+
+        + [PK#A76 / SK#A76]
+        +   PK: "PK#A76"
+        +   SK: "SK#A76"
+        +   _docVersion: 0
+        +   _tag: "A"
+        +   a: 76
+        +   pk: "PK#A76"
+        +   sk: "SK#A76"
+
+        + [PK#A77 / SK#A77]
+        +   PK: "PK#A77"
+        +   SK: "SK#A77"
+        +   _docVersion: 0
+        +   _tag: "A"
+        +   a: 77
+        +   pk: "PK#A77"
+        +   sk: "SK#A77"
+
+        + [PK#A78 / SK#A78]
+        +   PK: "PK#A78"
+        +   SK: "SK#A78"
+        +   _docVersion: 0
+        +   _tag: "A"
+        +   a: 78
+        +   pk: "PK#A78"
+        +   sk: "SK#A78"
+
+        + [PK#A79 / SK#A79]
+        +   PK: "PK#A79"
+        +   SK: "SK#A79"
+        +   _docVersion: 0
+        +   _tag: "A"
+        +   a: 79
+        +   pk: "PK#A79"
+        +   sk: "SK#A79"
+
+        + [PK#A8 / SK#A8]
+        +   PK: "PK#A8"
+        +   SK: "SK#A8"
+        +   _docVersion: 0
+        +   _tag: "A"
+        +   a: 8
+        +   pk: "PK#A8"
+        +   sk: "SK#A8"
+
+        + [PK#A80 / SK#A80]
+        +   PK: "PK#A80"
+        +   SK: "SK#A80"
+        +   _docVersion: 0
+        +   _tag: "A"
+        +   a: 80
+        +   pk: "PK#A80"
+        +   sk: "SK#A80"
+
+        + [PK#A81 / SK#A81]
+        +   PK: "PK#A81"
+        +   SK: "SK#A81"
+        +   _docVersion: 0
+        +   _tag: "A"
+        +   a: 81
+        +   pk: "PK#A81"
+        +   sk: "SK#A81"
+
+        + [PK#A82 / SK#A82]
+        +   PK: "PK#A82"
+        +   SK: "SK#A82"
+        +   _docVersion: 0
+        +   _tag: "A"
+        +   a: 82
+        +   pk: "PK#A82"
+        +   sk: "SK#A82"
+
+        + [PK#A83 / SK#A83]
+        +   PK: "PK#A83"
+        +   SK: "SK#A83"
+        +   _docVersion: 0
+        +   _tag: "A"
+        +   a: 83
+        +   pk: "PK#A83"
+        +   sk: "SK#A83"
+
+        + [PK#A84 / SK#A84]
+        +   PK: "PK#A84"
+        +   SK: "SK#A84"
+        +   _docVersion: 0
+        +   _tag: "A"
+        +   a: 84
+        +   pk: "PK#A84"
+        +   sk: "SK#A84"
+
+        + [PK#A85 / SK#A85]
+        +   PK: "PK#A85"
+        +   SK: "SK#A85"
+        +   _docVersion: 0
+        +   _tag: "A"
+        +   a: 85
+        +   pk: "PK#A85"
+        +   sk: "SK#A85"
+
+        + [PK#A86 / SK#A86]
+        +   PK: "PK#A86"
+        +   SK: "SK#A86"
+        +   _docVersion: 0
+        +   _tag: "A"
+        +   a: 86
+        +   pk: "PK#A86"
+        +   sk: "SK#A86"
+
+        + [PK#A87 / SK#A87]
+        +   PK: "PK#A87"
+        +   SK: "SK#A87"
+        +   _docVersion: 0
+        +   _tag: "A"
+        +   a: 87
+        +   pk: "PK#A87"
+        +   sk: "SK#A87"
+
+        + [PK#A88 / SK#A88]
+        +   PK: "PK#A88"
+        +   SK: "SK#A88"
+        +   _docVersion: 0
+        +   _tag: "A"
+        +   a: 88
+        +   pk: "PK#A88"
+        +   sk: "SK#A88"
+
+        + [PK#A89 / SK#A89]
+        +   PK: "PK#A89"
+        +   SK: "SK#A89"
+        +   _docVersion: 0
+        +   _tag: "A"
+        +   a: 89
+        +   pk: "PK#A89"
+        +   sk: "SK#A89"
+
+        + [PK#A9 / SK#A9]
+        +   PK: "PK#A9"
+        +   SK: "SK#A9"
+        +   _docVersion: 0
+        +   _tag: "A"
+        +   a: 9
+        +   pk: "PK#A9"
+        +   sk: "SK#A9"
+
+        + [PK#A90 / SK#A90]
+        +   PK: "PK#A90"
+        +   SK: "SK#A90"
+        +   _docVersion: 0
+        +   _tag: "A"
+        +   a: 90
+        +   pk: "PK#A90"
+        +   sk: "SK#A90"
+
+        + [PK#A91 / SK#A91]
+        +   PK: "PK#A91"
+        +   SK: "SK#A91"
+        +   _docVersion: 0
+        +   _tag: "A"
+        +   a: 91
+        +   pk: "PK#A91"
+        +   sk: "SK#A91"
+
+        + [PK#A92 / SK#A92]
+        +   PK: "PK#A92"
+        +   SK: "SK#A92"
+        +   _docVersion: 0
+        +   _tag: "A"
+        +   a: 92
+        +   pk: "PK#A92"
+        +   sk: "SK#A92"
+
+        + [PK#A93 / SK#A93]
+        +   PK: "PK#A93"
+        +   SK: "SK#A93"
+        +   _docVersion: 0
+        +   _tag: "A"
+        +   a: 93
+        +   pk: "PK#A93"
+        +   sk: "SK#A93"
+
+        + [PK#A94 / SK#A94]
+        +   PK: "PK#A94"
+        +   SK: "SK#A94"
+        +   _docVersion: 0
+        +   _tag: "A"
+        +   a: 94
+        +   pk: "PK#A94"
+        +   sk: "SK#A94"
+
+        + [PK#A95 / SK#A95]
+        +   PK: "PK#A95"
+        +   SK: "SK#A95"
+        +   _docVersion: 0
+        +   _tag: "A"
+        +   a: 95
+        +   pk: "PK#A95"
+        +   sk: "SK#A95"
+
+        + [PK#A96 / SK#A96]
+        +   PK: "PK#A96"
+        +   SK: "SK#A96"
+        +   _docVersion: 0
+        +   _tag: "A"
+        +   a: 96
+        +   pk: "PK#A96"
+        +   sk: "SK#A96"
+
+        + [PK#A97 / SK#A97]
+        +   PK: "PK#A97"
+        +   SK: "SK#A97"
+        +   _docVersion: 0
+        +   _tag: "A"
+        +   a: 97
+        +   pk: "PK#A97"
+        +   sk: "SK#A97"
+
+        + [PK#A98 / SK#A98]
+        +   PK: "PK#A98"
+        +   SK: "SK#A98"
+        +   _docVersion: 0
+        +   _tag: "A"
+        +   a: 98
+        +   pk: "PK#A98"
+        +   sk: "SK#A98"
+
+        + [PK#A99 / SK#A99]
+        +   PK: "PK#A99"
+        +   SK: "SK#A99"
+        +   _docVersion: 0
+        +   _tag: "A"
+        +   a: 99
+        +   pk: "PK#A99"
+        +   sk: "SK#A99"
+
+        + [PK#UPDATE / SK#UPDATE]
+        +   PK: "PK#UPDATE"
+        +   SK: "SK#UPDATE"
+        +   _docVersion: 1
+        +   _tag: "B"
+        +   b: "baz"
+        +   pk: "PK#UPDATE"
+        +   sk: "SK#UPDATE"
+
+        + [PK4 / PK4]
+        +   PK: "PK4"
+        +   SK: "PK4"
+        +   _docVersion: 0
+        +   _tag: "A"
+        +   a: 4
+        +   pk: "PK4"
+        +   sk: "PK4"
+
+        + [PK5 / PK5]
+        +   PK: "PK5"
+        +   SK: "PK5"
+        +   _docVersion: 0
+        +   _tag: "A"
+        +   a: 5
+        +   pk: "PK5"
+        +   sk: "PK5"
+
+        + [PK6 / SK6]
+        +   PK: "PK6"
+        +   SK: "SK6"
+        +   _docVersion: 0
+        +   _tag: "B"
+        +   b: "baz"
+        +   pk: "PK6"
+        +   sk: "SK6"
+      `)
       //#endregion
     })
 
@@ -2426,28 +2428,28 @@ describe("batchGet", () => {
         Object.entries(results).map(([key, val]) => [key, val.values()])
       )
     ).toMatchInlineSnapshot(`
-      Object {
-        "duplicate": Object {
+      {
+        "duplicate": {
           "a": 1,
           "pk": "PK#1",
           "sk": "SK#1",
         },
-        "four": Object {
+        "four": {
           "a": 4,
           "pk": "PK#4",
           "sk": "SK#4",
         },
-        "one": Object {
+        "one": {
           "a": 1,
           "pk": "PK#1",
           "sk": "SK#1",
         },
-        "three": Object {
+        "three": {
           "a": 3,
           "pk": "PK#3",
           "sk": "SK#3",
         },
-        "two": Object {
+        "two": {
           "a": 2,
           "pk": "PK#2",
           "sk": "SK#2",
@@ -2702,7 +2704,7 @@ describe("paginate", () => {
         }
       )
       expect(page1.pageInfo).toMatchInlineSnapshot(`
-        Object {
+        {
           "endCursor": "eyJQSyI6IlBLIiwiU0siOiIwMTkifQ==",
           "hasNextPage": true,
           "hasPreviousPage": false,
@@ -2722,7 +2724,7 @@ describe("paginate", () => {
         }
       )
       expect(page2.pageInfo).toMatchInlineSnapshot(`
-        Object {
+        {
           "endCursor": "eyJQSyI6IlBLIiwiU0siOiIwMzkifQ==",
           "hasNextPage": true,
           "hasPreviousPage": false,
@@ -2742,7 +2744,7 @@ describe("paginate", () => {
         }
       )
       expect(page3.pageInfo).toMatchInlineSnapshot(`
-        Object {
+        {
           "endCursor": "eyJQSyI6IlBLIiwiU0siOiIwNTkifQ==",
           "hasNextPage": false,
           "hasPreviousPage": false,
@@ -2763,7 +2765,7 @@ describe("paginate", () => {
         }
       )
       expect(backwardsPage2.pageInfo).toMatchInlineSnapshot(`
-        Object {
+        {
           "endCursor": "eyJQSyI6IlBLIiwiU0siOiIwMzkifQ==",
           "hasNextPage": false,
           "hasPreviousPage": true,
@@ -2783,7 +2785,7 @@ describe("paginate", () => {
         }
       )
       expect(backwardsPage1.pageInfo).toMatchInlineSnapshot(`
-        Object {
+        {
           "endCursor": "eyJQSyI6IlBLIiwiU0siOiIwMTkifQ==",
           "hasNextPage": false,
           "hasPreviousPage": false,
@@ -2814,7 +2816,7 @@ describe("paginate", () => {
         }
       )
       expect(page1.pageInfo).toMatchInlineSnapshot(`
-        Object {
+        {
           "endCursor": "eyJQSyI6IlBLIiwiU0siOiIwMTkifQ==",
           "hasNextPage": true,
           "hasPreviousPage": false,
@@ -2834,7 +2836,7 @@ describe("paginate", () => {
         }
       )
       expect(page2.pageInfo).toMatchInlineSnapshot(`
-        Object {
+        {
           "endCursor": "eyJQSyI6IlBLIiwiU0siOiIwMzkifQ==",
           "hasNextPage": true,
           "hasPreviousPage": false,
@@ -2854,7 +2856,7 @@ describe("paginate", () => {
         }
       )
       expect(page3.pageInfo).toMatchInlineSnapshot(`
-        Object {
+        {
           "endCursor": "eyJQSyI6IlBLIiwiU0siOiIwNTkifQ==",
           "hasNextPage": false,
           "hasPreviousPage": false,
@@ -2875,7 +2877,7 @@ describe("paginate", () => {
         }
       )
       expect(backwardsPage2.pageInfo).toMatchInlineSnapshot(`
-        Object {
+        {
           "endCursor": "eyJQSyI6IlBLIiwiU0siOiIwMzkifQ==",
           "hasNextPage": false,
           "hasPreviousPage": true,
@@ -2895,7 +2897,7 @@ describe("paginate", () => {
         }
       )
       expect(backwardsPage1.pageInfo).toMatchInlineSnapshot(`
-        Object {
+        {
           "endCursor": "eyJQSyI6IlBLIiwiU0siOiIwMTkifQ==",
           "hasNextPage": false,
           "hasPreviousPage": false,
@@ -2925,7 +2927,7 @@ describe("paginate", () => {
         }
       )
       expect(page.pageInfo).toMatchInlineSnapshot(`
-        Object {
+        {
           "endCursor": "eyJQSyI6IlBLIiwiU0siOiIwMDkifQ==",
           "hasNextPage": true,
           "hasPreviousPage": false,
@@ -2955,7 +2957,7 @@ describe("paginate", () => {
         }
       )
       expect(page1.pageInfo).toMatchInlineSnapshot(`
-        Object {
+        {
           "endCursor": "eyJQSyI6IlBLIiwiU0siOiIwNDkifQ==",
           "hasNextPage": true,
           "hasPreviousPage": false,
@@ -3036,7 +3038,7 @@ describe("paginate", () => {
         }
       )
       expect(page1.pageInfo).toMatchInlineSnapshot(`
-        Object {
+        {
           "endCursor": "eyJQSyI6IlBLIiwiU0siOiIwMTkifQ==",
           "hasNextPage": true,
           "hasPreviousPage": false,
@@ -3055,7 +3057,7 @@ describe("paginate", () => {
         }
       )
       expect(page2.pageInfo).toMatchInlineSnapshot(`
-        Object {
+        {
           "endCursor": "eyJQSyI6IlBLIiwiU0siOiIwMzkifQ==",
           "hasNextPage": true,
           "hasPreviousPage": false,
@@ -3074,7 +3076,7 @@ describe("paginate", () => {
         }
       )
       expect(page3.pageInfo).toMatchInlineSnapshot(`
-        Object {
+        {
           "endCursor": "eyJQSyI6IlBLIiwiU0siOiIwNTkifQ==",
           "hasNextPage": false,
           "hasPreviousPage": false,
@@ -3094,7 +3096,7 @@ describe("paginate", () => {
         }
       )
       expect(backwardsPage2.pageInfo).toMatchInlineSnapshot(`
-        Object {
+        {
           "endCursor": "eyJQSyI6IlBLIiwiU0siOiIwMzkifQ==",
           "hasNextPage": false,
           "hasPreviousPage": true,
@@ -3113,7 +3115,7 @@ describe("paginate", () => {
         }
       )
       expect(backwardsPage1.pageInfo).toMatchInlineSnapshot(`
-        Object {
+        {
           "endCursor": "eyJQSyI6IlBLIiwiU0siOiIwMTkifQ==",
           "hasNextPage": false,
           "hasPreviousPage": false,
@@ -3142,7 +3144,7 @@ describe("paginate", () => {
         }
       )
       expect(page.pageInfo).toMatchInlineSnapshot(`
-        Object {
+        {
           "endCursor": "eyJQSyI6IlBLIiwiU0siOiIwMDkifQ==",
           "hasNextPage": true,
           "hasPreviousPage": false,
@@ -3171,7 +3173,7 @@ describe("paginate", () => {
         }
       )
       expect(page1.pageInfo).toMatchInlineSnapshot(`
-        Object {
+        {
           "endCursor": "eyJQSyI6IlBLIiwiU0siOiIwNDkifQ==",
           "hasNextPage": true,
           "hasPreviousPage": false,
@@ -3251,7 +3253,7 @@ describe("paginate", () => {
         }
       )
       expect(page1.pageInfo).toMatchInlineSnapshot(`
-        Object {
+        {
           "endCursor": "eyJQSyI6IlBLIiwiU0siOiIwMTkifQ==",
           "hasNextPage": true,
           "hasPreviousPage": false,
@@ -3270,7 +3272,7 @@ describe("paginate", () => {
         }
       )
       expect(page2.pageInfo).toMatchInlineSnapshot(`
-        Object {
+        {
           "endCursor": "eyJQSyI6IlBLIiwiU0siOiIwMzkifQ==",
           "hasNextPage": true,
           "hasPreviousPage": false,
@@ -3289,7 +3291,7 @@ describe("paginate", () => {
         }
       )
       expect(page3.pageInfo).toMatchInlineSnapshot(`
-        Object {
+        {
           "endCursor": "eyJQSyI6IlBLIiwiU0siOiIwNTkifQ==",
           "hasNextPage": false,
           "hasPreviousPage": false,
@@ -3309,7 +3311,7 @@ describe("paginate", () => {
         }
       )
       expect(backwardsPage2.pageInfo).toMatchInlineSnapshot(`
-        Object {
+        {
           "endCursor": "eyJQSyI6IlBLIiwiU0siOiIwMzkifQ==",
           "hasNextPage": false,
           "hasPreviousPage": true,
@@ -3328,7 +3330,7 @@ describe("paginate", () => {
         }
       )
       expect(backwardsPage1.pageInfo).toMatchInlineSnapshot(`
-        Object {
+        {
           "endCursor": "eyJQSyI6IlBLIiwiU0siOiIwMTkifQ==",
           "hasNextPage": false,
           "hasPreviousPage": false,
@@ -3358,7 +3360,7 @@ describe("paginate", () => {
         }
       )
       expect(page.pageInfo).toMatchInlineSnapshot(`
-        Object {
+        {
           "endCursor": "eyJQSyI6IlBLIiwiU0siOiIwMDkifQ==",
           "hasNextPage": true,
           "hasPreviousPage": false,
@@ -3388,7 +3390,7 @@ describe("paginate", () => {
         }
       )
       expect(page1.pageInfo).toMatchInlineSnapshot(`
-        Object {
+        {
           "endCursor": "eyJQSyI6IlBLIiwiU0siOiIwNDkifQ==",
           "hasNextPage": true,
           "hasPreviousPage": false,

--- a/packages/dynamodb/src/__test__/conformance.test.ts
+++ b/packages/dynamodb/src/__test__/conformance.test.ts
@@ -1,7 +1,7 @@
 import { Client } from "../client"
 import { createSandbox, Sandbox } from "../sandbox"
 import { IN_MEMORY_SPEC } from "../in-memory/spec"
-import DynamoDB from "aws-sdk/clients/dynamodb"
+import DynamoDB from "../aws-sdk-v3-compat"
 
 type Engine = "local" | "memory"
 

--- a/packages/dynamodb/src/__test__/pagination.test.ts
+++ b/packages/dynamodb/src/__test__/pagination.test.ts
@@ -7,7 +7,7 @@ describe("encodeDDBCursor", () => {
     it("should encode basic PK and SK", () => {
       const result = encodeDDBCursor({
         PK: "USER#123",
-        SK: "PROFILE#456",
+        SK: "PROFILE#456"
       })
 
       expect(result).toMatchInlineSnapshot(
@@ -20,7 +20,7 @@ describe("encodeDDBCursor", () => {
         PK: "USER#123",
         SK: "PROFILE#456",
         GSI2PK: "GSI2PK#user123",
-        GSI2SK: "GSI2SK#profile456",
+        GSI2SK: "GSI2SK#profile456"
       })
 
       expect(result).toMatchInlineSnapshot(
@@ -35,7 +35,7 @@ describe("encodeDDBCursor", () => {
         GSI2PK: "GSI2PK#user123",
         GSI2SK: "GSI2SK#profile456",
         GSI3PK: "GSI3PK#fixed",
-        GSI3SK: "GSI3SK#value",
+        GSI3SK: "GSI3SK#value"
       })
 
       expect(result).toMatchInlineSnapshot(
@@ -51,7 +51,7 @@ describe("encodeDDBCursor", () => {
       const result = encodeDDBCursor(
         {
           PK: "USER#123",
-          SK: "PROFILE#456",
+          SK: "PROFILE#456"
         },
         encryptionKey
       )
@@ -66,7 +66,7 @@ describe("encodeDDBCursor", () => {
     it("should produce consistent encrypted results for same input", () => {
       const input = {
         PK: "USER#123",
-        SK: "PROFILE#456",
+        SK: "PROFILE#456"
       }
 
       const result1 = encodeDDBCursor(input, encryptionKey)
@@ -81,7 +81,7 @@ describe("encodeDDBCursor", () => {
           PK: "USER#123",
           SK: "PROFILE#456",
           GSI2PK: "GSI2PK#user123",
-          GSI2SK: "GSI2SK#profile456",
+          GSI2SK: "GSI2SK#profile456"
         },
         encryptionKey
       )
@@ -98,7 +98,7 @@ describe("decodeDDBCursor", () => {
       const result = decodeDDBCursor(encoded)
 
       expect(result).toMatchInlineSnapshot(`
-        Object {
+        {
           "PK": "USER#123",
           "SK": "PROFILE#456",
         }
@@ -111,7 +111,7 @@ describe("decodeDDBCursor", () => {
       const result = decodeDDBCursor(encoded, "GSI2")
 
       expect(result).toMatchInlineSnapshot(`
-        Object {
+        {
           "GSI2PK": "GSI2PK#user123",
           "GSI2SK": "GSI2SK#profile456",
           "PK": "USER#123",
@@ -126,7 +126,7 @@ describe("decodeDDBCursor", () => {
       const result = decodeDDBCursor(encoded, "GSI3")
 
       expect(result).toMatchInlineSnapshot(`
-        Object {
+        {
           "GSI3PK": "GSI3PK#fixed",
           "GSI3SK": "GSI3SK#value",
           "PK": "USER#123",
@@ -142,13 +142,13 @@ describe("decodeDDBCursor", () => {
     it("should decode encrypted cursor", () => {
       const input = {
         PK: "USER#123",
-        SK: "PROFILE#456",
+        SK: "PROFILE#456"
       }
       const encoded = encodeDDBCursor(input, encryptionKey)
       const result = decodeDDBCursor(encoded, undefined, encryptionKey)
 
       expect(result).toMatchInlineSnapshot(`
-        Object {
+        {
           "PK": "USER#123",
           "SK": "PROFILE#456",
         }
@@ -160,13 +160,13 @@ describe("decodeDDBCursor", () => {
         PK: "USER#123",
         SK: "PROFILE#456",
         GSI2PK: "GSI2PK#user123",
-        GSI2SK: "GSI2SK#profile456",
+        GSI2SK: "GSI2SK#profile456"
       }
       const encoded = encodeDDBCursor(input, encryptionKey)
       const result = decodeDDBCursor(encoded, "GSI2", encryptionKey)
 
       expect(result).toMatchInlineSnapshot(`
-        Object {
+        {
           "GSI2PK": "GSI2PK#user123",
           "GSI2SK": "GSI2SK#profile456",
           "PK": "USER#123",
@@ -179,7 +179,7 @@ describe("decodeDDBCursor", () => {
       const wrongKey = crypto.randomBytes(32)
       const input = {
         PK: "USER#123",
-        SK: "PROFILE#456",
+        SK: "PROFILE#456"
       }
       const encoded = encodeDDBCursor(input, encryptionKey)
 
@@ -250,7 +250,7 @@ describe("decodeDDBCursor", () => {
     it("should round-trip basic values", () => {
       const input = {
         PK: "USER#123",
-        SK: "PROFILE#456",
+        SK: "PROFILE#456"
       }
       const encoded = encodeDDBCursor(input)
       const decoded = decodeDDBCursor(encoded)
@@ -265,7 +265,7 @@ describe("decodeDDBCursor", () => {
         GSI2PK: "GSI2PK#user123",
         GSI2SK: "GSI2SK#profile456",
         GSI3PK: "GSI3PK#fixed",
-        GSI3SK: "GSI3SK#value",
+        GSI3SK: "GSI3SK#value"
       }
       const encoded = encodeDDBCursor(input)
       const decoded = decodeDDBCursor(encoded, "GSI2")
@@ -274,7 +274,7 @@ describe("decodeDDBCursor", () => {
         PK: input.PK,
         SK: input.SK,
         GSI2PK: input.GSI2PK,
-        GSI2SK: input.GSI2SK,
+        GSI2SK: input.GSI2SK
       })
     })
 
@@ -284,7 +284,7 @@ describe("decodeDDBCursor", () => {
         PK: "USER#123",
         SK: "PROFILE#456",
         GSI2PK: "GSI2PK#user123",
-        GSI2SK: "GSI2SK#profile456",
+        GSI2SK: "GSI2SK#profile456"
       }
       const encoded = encodeDDBCursor(input, encryptionKey)
       const decoded = decodeDDBCursor(encoded, "GSI2", encryptionKey)
@@ -293,7 +293,7 @@ describe("decodeDDBCursor", () => {
         PK: input.PK,
         SK: input.SK,
         GSI2PK: input.GSI2PK,
-        GSI2SK: input.GSI2SK,
+        GSI2SK: input.GSI2SK
       })
     })
   })

--- a/packages/dynamodb/src/aws-sdk-v3-compat.ts
+++ b/packages/dynamodb/src/aws-sdk-v3-compat.ts
@@ -1,0 +1,296 @@
+import {
+  CreateTableCommand,
+  DeleteTableCommand,
+  DynamoDBClient,
+  DynamoDBClientConfig,
+  waitUntilTableExists,
+  waitUntilTableNotExists,
+  CreateTableCommandInput,
+  CreateTableCommandOutput,
+  DeleteTableCommandInput,
+  DeleteTableCommandOutput,
+} from "@aws-sdk/client-dynamodb"
+import {
+  BatchGetCommand,
+  BatchGetCommandInput,
+  BatchGetCommandOutput,
+  BatchWriteCommand,
+  BatchWriteCommandInput,
+  BatchWriteCommandOutput,
+  DeleteCommand,
+  DeleteCommandInput,
+  DeleteCommandOutput,
+  DynamoDBDocumentClient,
+  GetCommand,
+  GetCommandInput,
+  GetCommandOutput,
+  PutCommand,
+  PutCommandInput,
+  PutCommandOutput,
+  QueryCommand,
+  QueryCommandInput,
+  QueryCommandOutput,
+  ScanCommand,
+  ScanCommandInput,
+  ScanCommandOutput,
+  TransactWriteCommand,
+  TransactWriteCommandInput,
+  TransactWriteCommandOutput,
+  UpdateCommand,
+  UpdateCommandInput,
+  UpdateCommandOutput,
+} from "@aws-sdk/lib-dynamodb"
+
+interface PromiseRequest<T> {
+  promise: () => Promise<T>
+}
+
+export interface AWSError extends Error {
+  code: string
+  [key: string]: any
+}
+
+export interface ServiceConfigurationOptions extends DynamoDBClientConfig {
+  accessKeyId?: string
+  secretAccessKey?: string
+  sessionToken?: string
+}
+
+export interface ClientApiVersions {}
+
+interface DocumentTranslationOptions {
+  convertEmptyValues?: boolean
+  wrapNumbers?: boolean
+  marshallOptions?: { [key: string]: unknown }
+  unmarshallOptions?: { [key: string]: unknown }
+}
+
+const withoutUndefined = <T extends { [key: string]: any }>(value: T): T =>
+  Object.fromEntries(
+    Object.entries(value).filter(([, entry]) => typeof entry !== "undefined")
+  ) as T
+
+const normalizeClientConfig = (
+  config: (ServiceConfigurationOptions & DocumentTranslationOptions) | undefined
+) => {
+  const {
+    accessKeyId,
+    secretAccessKey,
+    sessionToken,
+    convertEmptyValues,
+    wrapNumbers,
+    marshallOptions,
+    unmarshallOptions,
+    ...clientConfig
+  } = config ?? {}
+
+  const normalizedClientConfig = withoutUndefined({
+    ...clientConfig,
+  }) as DynamoDBClientConfig
+
+  if (!normalizedClientConfig.credentials && accessKeyId && secretAccessKey) {
+    normalizedClientConfig.credentials = withoutUndefined({
+      accessKeyId,
+      secretAccessKey,
+      sessionToken,
+    })
+  }
+
+  return {
+    clientConfig: normalizedClientConfig,
+    translateConfig: {
+      marshallOptions: withoutUndefined({
+        convertEmptyValues,
+        removeUndefinedValues: true,
+        ...(marshallOptions ?? {}),
+      }),
+      unmarshallOptions: withoutUndefined({
+        wrapNumbers,
+        ...(unmarshallOptions ?? {}),
+      }),
+    },
+  }
+}
+
+const normalizeOutput = <T>(output: T): T => {
+  if (!output || typeof output !== "object") return output
+
+  const { $metadata, ...rest } = output as any
+  return rest as T
+}
+
+const normalizeError = (error: unknown): AWSError => {
+  if (error && typeof error === "object") {
+    const candidate = error as AWSError
+    if (!candidate.code && typeof candidate.name === "string") {
+      candidate.code = candidate.name
+    }
+    return candidate
+  }
+
+  const wrapped = new Error(String(error)) as AWSError
+  wrapped.code = "UnknownError"
+  return wrapped
+}
+
+const request = <T>(fn: () => Promise<T>): PromiseRequest<T> => ({
+  promise: async () => {
+    try {
+      return normalizeOutput(await fn())
+    } catch (error) {
+      throw normalizeError(error)
+    }
+  },
+})
+
+export class DocumentClient {
+  private readonly client: DynamoDBDocumentClient
+
+  constructor(config?: DocumentClient.DocumentClientOptions) {
+    const { clientConfig, translateConfig } = normalizeClientConfig(config)
+    this.client = DynamoDBDocumentClient.from(
+      new DynamoDBClient(clientConfig),
+      translateConfig
+    )
+  }
+
+  get(params: DocumentClient.GetItemInput) {
+    return request<DocumentClient.GetItemOutput>(() =>
+      this.client.send(new GetCommand(params))
+    )
+  }
+
+  put(params: DocumentClient.PutItemInput) {
+    return request<DocumentClient.PutItemOutput>(() =>
+      this.client.send(new PutCommand(params))
+    )
+  }
+
+  update(params: DocumentClient.UpdateItemInput) {
+    return request<DocumentClient.UpdateItemOutput>(() =>
+      this.client.send(new UpdateCommand(params))
+    )
+  }
+
+  delete(params: DocumentClient.DeleteItemInput) {
+    return request<DocumentClient.DeleteItemOutput>(() =>
+      this.client.send(new DeleteCommand(params))
+    )
+  }
+
+  query(params: DocumentClient.QueryInput) {
+    return request<DocumentClient.QueryOutput>(() =>
+      this.client.send(new QueryCommand(params))
+    )
+  }
+
+  scan(params: DocumentClient.ScanInput) {
+    return request<DocumentClient.ScanOutput>(() =>
+      this.client.send(new ScanCommand(params))
+    )
+  }
+
+  batchGet(params: DocumentClient.BatchGetItemInput) {
+    return request<DocumentClient.BatchGetItemOutput>(() =>
+      this.client.send(new BatchGetCommand(params))
+    )
+  }
+
+  batchWrite(params: DocumentClient.BatchWriteItemInput) {
+    return request<DocumentClient.BatchWriteItemOutput>(async () => ({
+      UnprocessedItems: {},
+      ...(await this.client.send(new BatchWriteCommand(params))),
+    }))
+  }
+
+  transactWrite(params: DocumentClient.TransactWriteItemsInput) {
+    return request<DocumentClient.TransactWriteItemsOutput>(() =>
+      this.client.send(new TransactWriteCommand(params))
+    )
+  }
+}
+
+export namespace DocumentClient {
+  export interface DocumentClientOptions
+    extends ServiceConfigurationOptions,
+      DocumentTranslationOptions {}
+
+  export type Key = { [key: string]: any }
+  export type GetItemInput = GetCommandInput
+  export type GetItemOutput = GetCommandOutput
+  export type PutItemInput = PutCommandInput
+  export type PutItemOutput = PutCommandOutput
+  export type UpdateItemInput = UpdateCommandInput
+  export type UpdateItemOutput = UpdateCommandOutput
+  export type DeleteItemInput = DeleteCommandInput
+  export type DeleteItemOutput = DeleteCommandOutput
+  export type QueryInput = QueryCommandInput
+  export type QueryOutput = QueryCommandOutput
+  export type ScanInput = ScanCommandInput
+  export type ScanOutput = ScanCommandOutput
+  export type BatchGetItemInput = BatchGetCommandInput
+  export type BatchGetItemOutput = BatchGetCommandOutput
+  export type BatchWriteItemInput = BatchWriteCommandInput
+  export type BatchWriteItemOutput = BatchWriteCommandOutput
+  export type TransactWriteItemsInput = TransactWriteCommandInput
+  export type TransactWriteItemsOutput = TransactWriteCommandOutput
+  export type TransactWriteItem = NonNullable<
+    TransactWriteCommandInput["TransactItems"]
+  >[number]
+  export type ConditionCheck = NonNullable<
+    TransactWriteItem["ConditionCheck"]
+  >
+}
+
+export class DynamoDB {
+  private readonly client: DynamoDBClient
+
+  constructor(config?: ServiceConfigurationOptions) {
+    const { clientConfig } = normalizeClientConfig(config)
+    this.client = new DynamoDBClient(clientConfig)
+  }
+
+  createTable(params: DynamoDB.CreateTableInput) {
+    return request<DynamoDB.CreateTableOutput>(() =>
+      this.client.send(new CreateTableCommand(params))
+    )
+  }
+
+  deleteTable(params: DynamoDB.DeleteTableInput) {
+    return request<DynamoDB.DeleteTableOutput>(() =>
+      this.client.send(new DeleteTableCommand(params))
+    )
+  }
+
+  waitFor(state: DynamoDB.WaiterState, params: DynamoDB.WaiterInput) {
+    return request(async () => {
+      switch (state) {
+        case "tableExists":
+          await waitUntilTableExists(
+            { client: this.client, maxWaitTime: 60, minDelay: 1 },
+            params
+          )
+          break
+        case "tableNotExists":
+          await waitUntilTableNotExists(
+            { client: this.client, maxWaitTime: 60, minDelay: 1 },
+            params
+          )
+          break
+      }
+
+      return {}
+    })
+  }
+}
+
+export namespace DynamoDB {
+  export type CreateTableInput = CreateTableCommandInput
+  export type CreateTableOutput = CreateTableCommandOutput
+  export type DeleteTableInput = DeleteTableCommandInput
+  export type DeleteTableOutput = DeleteTableCommandOutput
+  export type WaiterInput = { TableName: string }
+  export type WaiterState = "tableExists" | "tableNotExists"
+}
+
+export default DynamoDB

--- a/packages/dynamodb/src/client.ts
+++ b/packages/dynamodb/src/client.ts
@@ -1,6 +1,9 @@
-import { DocumentClient, ClientApiVersions } from "aws-sdk/clients/dynamodb"
-import { ServiceConfigurationOptions } from "aws-sdk/lib/service"
-import { AWSError } from "aws-sdk/lib/error"
+import {
+  AWSError,
+  ClientApiVersions,
+  DocumentClient,
+  ServiceConfigurationOptions,
+} from "./aws-sdk-v3-compat"
 import { pipe, absurd } from "fp-ts/lib/function"
 import * as A from "fp-ts/lib/Array"
 import * as E from "fp-ts/lib/Either"

--- a/packages/dynamodb/src/errors.ts
+++ b/packages/dynamodb/src/errors.ts
@@ -1,4 +1,4 @@
-import { AWSError } from "aws-sdk/lib/error"
+import { AWSError } from "./aws-sdk-v3-compat"
 import { BulkOperation } from "./operations"
 
 // TODO: populate errors with more info

--- a/packages/dynamodb/src/index.ts
+++ b/packages/dynamodb/src/index.ts
@@ -1,4 +1,5 @@
 export * from "./client"
+export * from "./aws-sdk-v3-compat"
 export * from "./dynamodb-model"
 export * from "./errors"
 export * from "./pagination"

--- a/packages/dynamodb/src/operations.ts
+++ b/packages/dynamodb/src/operations.ts
@@ -1,4 +1,4 @@
-import { DocumentClient } from "aws-sdk/clients/dynamodb"
+import { DocumentClient } from "./aws-sdk-v3-compat"
 import { TypeOf } from "@model-ts/core"
 import {
   DynamoDBModelInstance,

--- a/packages/dynamodb/src/sandbox.ts
+++ b/packages/dynamodb/src/sandbox.ts
@@ -1,6 +1,6 @@
 import crypto from "crypto"
 import { chunksOf } from "fp-ts/lib/Array"
-import DynamoDB from "aws-sdk/clients/dynamodb"
+import DynamoDB, { DocumentClient } from "./aws-sdk-v3-compat"
 import { formatSnapshotDiff } from "./diff"
 import { Client } from "./client"
 import { GSI_NAMES } from "./gsi"
@@ -13,7 +13,7 @@ const ddb = new DynamoDB({
   region: "local",
 })
 
-const docClient = new DynamoDB.DocumentClient({
+const docClient = new DocumentClient({
   accessKeyId: "xxx",
   secretAccessKey: "xxx",
   endpoint: process.env.LOCAL_ENDPOINT,
@@ -27,45 +27,44 @@ export const createTable = async () => {
     .createTable({
       TableName: tableName,
       AttributeDefinitions: [
-        { AttributeName: "PK", AttributeType: "S" },
-        { AttributeName: "SK", AttributeType: "S" },
+        { AttributeName: "PK", AttributeType: "S" as const },
+        { AttributeName: "SK", AttributeType: "S" as const },
         ...GSI_NAMES.flatMap((GSI) => [
-          { AttributeName: `${GSI}PK`, AttributeType: "S" },
-          { AttributeName: `${GSI}SK`, AttributeType: "S" },
+          { AttributeName: `${GSI}PK`, AttributeType: "S" as const },
+          { AttributeName: `${GSI}SK`, AttributeType: "S" as const },
         ]),
       ],
       KeySchema: [
-        { AttributeName: "PK", KeyType: "HASH" },
-        { AttributeName: "SK", KeyType: "RANGE" },
+        { AttributeName: "PK", KeyType: "HASH" as const },
+        { AttributeName: "SK", KeyType: "RANGE" as const },
       ],
       GlobalSecondaryIndexes: [
         {
           IndexName: "GSI1",
           KeySchema: [
-            { AttributeName: "SK", KeyType: "HASH" },
-            { AttributeName: "PK", KeyType: "RANGE" },
+            { AttributeName: "SK", KeyType: "HASH" as const },
+            { AttributeName: "PK", KeyType: "RANGE" as const },
           ],
           Projection: {
-            ProjectionType: "ALL",
+            ProjectionType: "ALL" as const,
           },
         },
         ...GSI_NAMES.map((GSI) => ({
           IndexName: GSI,
           KeySchema: [
-            { AttributeName: `${GSI}PK`, KeyType: "HASH" },
-            { AttributeName: `${GSI}SK`, KeyType: "RANGE" },
+            { AttributeName: `${GSI}PK`, KeyType: "HASH" as const },
+            { AttributeName: `${GSI}SK`, KeyType: "RANGE" as const },
           ],
           Projection: {
-            ProjectionType: "ALL",
+            ProjectionType: "ALL" as const,
           },
         })),
       ],
-      BillingMode: "PAY_PER_REQUEST",
+      BillingMode: "PAY_PER_REQUEST" as const,
     })
     .promise()
     .catch((e: any) => {
-      console.log("Failed to create table, exiting.", e)
-      process.exit(1)
+      throw e
     })
 
   return tableName
@@ -77,8 +76,7 @@ export const destroyTable = async (tableName: string) => {
     .promise()
     .then(() => {})
     .catch((e) => {
-      console.log("Failed to destroy table, exiting.", e)
-      process.exit(1)
+      throw e
     })
 }
 
@@ -125,7 +123,7 @@ const WRITE_METHODS = new Set([
 ])
 
 function createTrackedDocClient(
-  original: DynamoDB.DocumentClient,
+  original: DocumentClient,
   tableName: string
 ) {
   let isTracking = false
@@ -222,7 +220,7 @@ function createTrackedDocClient(
   })
 
   return {
-    proxy: proxy as DynamoDB.DocumentClient,
+    proxy: proxy as DocumentClient,
     startTracking: () => {
       isTracking = true
       trackedKeys.clear()
@@ -285,7 +283,7 @@ export const createSandbox = async (client: Client): Promise<Sandbox> => {
   if (process.env.EXPERIMENTAL_DYNAMODB_IN_MEMORY === "1") {
     const tableName = crypto.randomBytes(20).toString("hex")
     const inMemoryClient =
-      createInMemoryDocumentClient() as any as DynamoDB.DocumentClient & {
+      createInMemoryDocumentClient() as any as DocumentClient & {
         __inMemorySnapshot: (name: string) => { [key: string]: any }
         __inMemoryResetTable: (name: string) => void
       }

--- a/packages/eventbridge/README.md
+++ b/packages/eventbridge/README.md
@@ -1,14 +1,9 @@
 # @model-ts/eventbridge
 
-> model-ts Provider for AWS EventBridge.
+> model-ts Provider for AWS EventBridge using AWS SDK for JavaScript v3.
 
-Use cases [✔️][❌]
-
-✔️ should call `provider.publish()` with correct values<br>
-✔️ should call `eventBridge.putEvents()` with correct values<br>
-✔️ should throw if no results<br>
-✔️ should throw if `FailedEntryCount`<br>
-✔️ should return `results.Entries`<br>
+This package uses AWS SDK for JavaScript v3. Make sure that you have
+`@aws-sdk/client-eventbridge` installed.
 
 ## License
 

--- a/packages/eventbridge/jest.config.js
+++ b/packages/eventbridge/jest.config.js
@@ -2,12 +2,18 @@ module.exports = {
   preset: "ts-jest",
   testMatch: ["**/*.test.ts"],
   transform: {
-    "^.+\\.ts$": "ts-jest",
+    "^.+\\.[tj]s$": [
+      "ts-jest",
+      {
+        tsconfig: {
+          allowJs: true,
+        },
+      },
+    ],
   },
+  transformIgnorePatterns: [
+    "/node_modules/(?!(@aws-sdk|@smithy)/)",
+    "packages/core/dist/",
+  ],
   setupFilesAfterEnv: ["./src/test-utils/setup.ts"],
-  globals: {
-    "ts-jest": {
-      isolatedModules: true,
-    },
-  },
 }

--- a/packages/eventbridge/package.json
+++ b/packages/eventbridge/package.json
@@ -5,6 +5,9 @@
   "module": "dist/esm/index.js",
   "author": "Fabian Finke <finkef@icloud.com>",
   "license": "MIT",
+  "engines": {
+    "node": ">=20"
+  },
   "scripts": {
     "build": "tsc -b",
     "build:esm": "tsc -b tsconfig.esm.json",
@@ -13,18 +16,18 @@
   "keywords": [],
   "peerDependencies": {
     "@model-ts/core": "^0.4.2",
-    "aws-sdk": "^2.691.0"
+    "@aws-sdk/client-eventbridge": "^3.0.0"
   },
   "devDependencies": {
+    "@aws-sdk/client-eventbridge": "^3.0.0",
     "@model-ts/core": "*",
-    "@types/jest": "^26.0.24",
+    "@types/jest": "^29.5.0",
     "@types/uuid": "^8.3.0",
-    "aws-sdk": "^2.691.0",
     "io-ts": "^2.2.4",
-    "jest": "^27.0.4",
+    "jest": "^29.7.0",
     "mockdate": "^3.0.5",
     "prettier": "^2.2.1",
-    "ts-jest": "^27.1.3",
+    "ts-jest": "^29.2.5",
     "typescript": "~4.5.5",
     "uuid": "^8.3.2"
   }

--- a/packages/eventbridge/src/__tests__/provider.test.ts
+++ b/packages/eventbridge/src/__tests__/provider.test.ts
@@ -1,14 +1,12 @@
 import * as t from "io-ts"
 import { model } from "@model-ts/core"
 import { EventBridgeProvider, getProvider } from "../provider"
-import EventBridge from "aws-sdk/clients/eventbridge"
+import { EventBridgeClient, PutEventsCommand } from "@aws-sdk/client-eventbridge"
 import { Client } from "../client"
-
-jest.mock("aws-sdk/clients/eventbridge")
 
 const EVENT_BUS_NAME = "any-event-bus"
 
-const makeSut = (eventBridgeClient: EventBridge): EventBridgeProvider => {
+const makeSut = (eventBridgeClient: EventBridgeClient): EventBridgeProvider => {
   const client = new Client({ eventBusName: EVENT_BUS_NAME })
 
   client.eventBridgeClient = eventBridgeClient
@@ -36,13 +34,10 @@ const mockEvent = (provider: EventBridgeProvider) => {
 }
 
 it("should call provider.publish()", async () => {
-  const client = new EventBridge()
-  client.putEvents = jest.fn().mockImplementationOnce(() => ({
-    promise: () =>
-      Promise.resolve({
-        Entries: [],
-      }),
-  }))
+  const client = new EventBridgeClient({})
+  client.send = jest.fn().mockResolvedValueOnce({
+    Entries: [],
+  })
   const provider = makeSut(client)
   provider.instanceProps.publish = jest.fn()
   const { event } = mockEvent(provider)
@@ -50,74 +45,64 @@ it("should call provider.publish()", async () => {
   expect(provider.instanceProps.publish).toHaveBeenCalled()
 })
 
-it("should call eventBridge.putEvents() with correct values", async () => {
-  const client = new EventBridge()
+it("should call EventBridgeClient.send() with correct values", async () => {
+  const client = new EventBridgeClient({})
   const { event } = mockEvent(makeSut(client))
-  client.putEvents = jest.fn().mockImplementationOnce(() => ({
-    promise: () =>
-      Promise.resolve({
-        Entries: [],
-      }),
-  }))
+  client.send = jest.fn().mockResolvedValueOnce({
+    Entries: [],
+  })
   await event.publish()
-  expect(client.putEvents).toHaveBeenCalledWith({
+  expect(client.send).toHaveBeenCalledWith(expect.any(PutEventsCommand))
+  expect((client.send as jest.Mock).mock.calls[0][0].input).toEqual({
     Entries: [
       {
         EventBusName: EVENT_BUS_NAME,
         Source: event.source,
         DetailType: event.detailType,
-        Detail: event.encode(),
+        Detail: JSON.stringify(event.encode()),
       },
     ],
   })
 })
 
 it("should succeed if no results", async () => {
-  const client = new EventBridge()
-  client.putEvents = jest.fn().mockImplementationOnce(() => ({
-    promise: () => Promise.resolve({}),
-  }))
+  const client = new EventBridgeClient({})
+  client.send = jest.fn().mockResolvedValueOnce({})
   const { event } = mockEvent(makeSut(client))
   const promise = event.publish()
   await expect(promise).resolves.toEqual([])
 })
 
 it("should throw if FailedEntryCount > 0", async () => {
-  const client = new EventBridge()
-  client.putEvents = jest.fn().mockImplementationOnce(() => ({
-    promise: () =>
-      Promise.resolve({
-        FailedEntryCount: 1,
-      }),
-  }))
+  const client = new EventBridgeClient({})
+  client.send = jest.fn().mockResolvedValueOnce({
+    FailedEntryCount: 1,
+  })
   const { event } = mockEvent(makeSut(client))
   const promise = event.publish()
   await expect(promise).rejects.toThrow()
 })
 
 it("should return Entries", async () => {
-  const client = new EventBridge()
+  const client = new EventBridgeClient({})
   const { event } = mockEvent(makeSut(client))
-  client.putEvents = jest.fn().mockImplementationOnce(() => ({
-    promise: () =>
-      Promise.resolve({
-        Entries: [
-          {
-            EventBusName: EVENT_BUS_NAME,
-            Source: "core",
-            DetailType: "core.user.created",
-            Detail: event.encode(),
-          },
-        ],
-      }),
-  }))
+  client.send = jest.fn().mockResolvedValueOnce({
+    Entries: [
+      {
+        EventBusName: EVENT_BUS_NAME,
+        Source: "core",
+        DetailType: "core.user.created",
+        Detail: JSON.stringify(event.encode()),
+      },
+    ],
+  })
   const results = await event.publish()
   expect(results).toEqual([
     {
       EventBusName: EVENT_BUS_NAME,
       Source: "core",
       DetailType: "core.user.created",
-      Detail: event.encode(),
+      Detail: JSON.stringify(event.encode()),
     },
   ])
 })

--- a/packages/eventbridge/src/client.ts
+++ b/packages/eventbridge/src/client.ts
@@ -1,18 +1,24 @@
 import { ModelInstance } from "@model-ts/core"
-import EventBridge, { ClientConfiguration } from "aws-sdk/clients/eventbridge"
+import {
+  EventBridgeClient,
+  EventBridgeClientConfig,
+  PutEventsCommand,
+  PutEventsCommandOutput,
+} from "@aws-sdk/client-eventbridge"
 import { PublishError } from "./errors"
 
-export interface ClientProps extends ClientConfiguration {
+export interface ClientProps extends EventBridgeClientConfig {
   eventBusName: string
 }
 
 export class Client {
   eventBusName: string
-  eventBridgeClient: EventBridge
+  eventBridgeClient: EventBridgeClient
 
   constructor(options: ClientProps) {
-    this.eventBridgeClient = new EventBridge(options)
-    this.eventBusName = options.eventBusName
+    const { eventBusName, ...clientOptions } = options
+    this.eventBridgeClient = new EventBridgeClient(clientOptions)
+    this.eventBusName = eventBusName
   }
 
   async publish(
@@ -27,12 +33,12 @@ export class Client {
 
     const chunks = chunk(events, 10)
 
-    const entries: EventBridge.PutEventsResultEntry[] = []
+    const entries: NonNullable<PutEventsCommandOutput["Entries"]> = []
     let failedCount = 0
 
     for (const chunk of chunks) {
-      const { Entries, FailedEntryCount } = await this.eventBridgeClient
-        .putEvents({
+      const { Entries, FailedEntryCount } = await this.eventBridgeClient.send(
+        new PutEventsCommand({
           Entries: chunk.map((event) => ({
             EventBusName: this.eventBusName,
             Source: event.source,
@@ -40,7 +46,7 @@ export class Client {
             Detail: JSON.stringify(event.encode()),
           })),
         })
-        .promise()
+      )
 
       failedCount += FailedEntryCount ?? 0
       entries.push(...(Entries ?? []))

--- a/packages/eventbridge/src/provider.ts
+++ b/packages/eventbridge/src/provider.ts
@@ -1,5 +1,5 @@
 import { ModelInstance, Provider } from "@model-ts/core"
-import EventBridge from "aws-sdk/clients/eventbridge"
+import { PutEventsCommandOutput } from "@aws-sdk/client-eventbridge"
 import { Client } from "./client"
 
 export interface EventBridgeProvider extends Provider {
@@ -11,7 +11,7 @@ export interface EventBridgeProvider extends Provider {
       }
     >(
       this: T
-    ) => Promise<EventBridge.PutEventsResponse["Entries"]>
+    ) => Promise<PutEventsCommandOutput["Entries"]>
   }
 }
 

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "strict": true,
     "incremental": true,
-    "lib": ["ES2019"],
+    "lib": ["ES2019", "WebWorker"],
     "target": "ES6",
     "module": "commonjs",
     "declaration": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,324 @@
 # yarn lockfile v1
 
 
+"@aws-crypto/crc32@5.2.0":
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/@aws-crypto/crc32/-/crc32-5.2.0.tgz#cfcc22570949c98c6689cfcbd2d693d36cdae2e1"
+  integrity sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg==
+  dependencies:
+    "@aws-crypto/util" "^5.2.0"
+    "@aws-sdk/types" "^3.222.0"
+    tslib "^2.6.2"
+
+"@aws-crypto/sha256-browser@5.2.0":
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz#153895ef1dba6f9fce38af550e0ef58988eb649e"
+  integrity sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==
+  dependencies:
+    "@aws-crypto/sha256-js" "^5.2.0"
+    "@aws-crypto/supports-web-crypto" "^5.2.0"
+    "@aws-crypto/util" "^5.2.0"
+    "@aws-sdk/types" "^3.222.0"
+    "@aws-sdk/util-locate-window" "^3.0.0"
+    "@smithy/util-utf8" "^2.0.0"
+    tslib "^2.6.2"
+
+"@aws-crypto/sha256-js@5.2.0", "@aws-crypto/sha256-js@^5.2.0":
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz#c4fdb773fdbed9a664fc1a95724e206cf3860042"
+  integrity sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==
+  dependencies:
+    "@aws-crypto/util" "^5.2.0"
+    "@aws-sdk/types" "^3.222.0"
+    tslib "^2.6.2"
+
+"@aws-crypto/supports-web-crypto@^5.2.0":
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/@aws-crypto/supports-web-crypto/-/supports-web-crypto-5.2.0.tgz#a1e399af29269be08e695109aa15da0a07b5b5fb"
+  integrity sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==
+  dependencies:
+    tslib "^2.6.2"
+
+"@aws-crypto/util@^5.2.0":
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/@aws-crypto/util/-/util-5.2.0.tgz#71284c9cffe7927ddadac793c14f14886d3876da"
+  integrity sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==
+  dependencies:
+    "@aws-sdk/types" "^3.222.0"
+    "@smithy/util-utf8" "^2.0.0"
+    tslib "^2.6.2"
+
+"@aws-sdk/client-dynamodb@^3.0.0":
+  version "3.1068.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/client-dynamodb/-/client-dynamodb-3.1068.0.tgz#0bbaf72b09694fcd0457e20d531ef627adcc692e"
+  integrity sha512-DOMUWnLSFHaRC0EixpWMnrQcQaV08P5rzAUdRTEkx72NaDRF0Q6+3QdtqX8ocyHfySzwMwOE9/vHRmhNvWHl/g==
+  dependencies:
+    "@aws-crypto/sha256-browser" "5.2.0"
+    "@aws-crypto/sha256-js" "5.2.0"
+    "@aws-sdk/core" "^3.974.20"
+    "@aws-sdk/credential-provider-node" "^3.972.55"
+    "@aws-sdk/dynamodb-codec" "^3.973.20"
+    "@aws-sdk/middleware-endpoint-discovery" "^3.972.18"
+    "@aws-sdk/types" "^3.973.12"
+    "@smithy/core" "^3.24.6"
+    "@smithy/fetch-http-handler" "^5.4.6"
+    "@smithy/node-http-handler" "^4.7.6"
+    "@smithy/types" "^4.14.3"
+    tslib "^2.6.2"
+
+"@aws-sdk/client-eventbridge@^3.0.0":
+  version "3.1068.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/client-eventbridge/-/client-eventbridge-3.1068.0.tgz#e565cfd7cd6dde8eb115947c83c14b3b11c8e51b"
+  integrity sha512-vHorSGf+SAYymXMernZcvVlTUrmEOwemmEqQv8HLwaRuzfqlPYeAqN20y7O1N5YlVuRkTMNzB02pM141mJozdQ==
+  dependencies:
+    "@aws-crypto/sha256-browser" "5.2.0"
+    "@aws-crypto/sha256-js" "5.2.0"
+    "@aws-sdk/core" "^3.974.20"
+    "@aws-sdk/credential-provider-node" "^3.972.55"
+    "@aws-sdk/signature-v4-multi-region" "^3.996.34"
+    "@aws-sdk/types" "^3.973.12"
+    "@smithy/core" "^3.24.6"
+    "@smithy/fetch-http-handler" "^5.4.6"
+    "@smithy/node-http-handler" "^4.7.6"
+    "@smithy/types" "^4.14.3"
+    tslib "^2.6.2"
+
+"@aws-sdk/core@^3.974.20":
+  version "3.974.20"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/core/-/core-3.974.20.tgz#fc9727897662e148fad2276995298f56b587c3ab"
+  integrity sha512-7sDi2B2N3mc3nf1nz6FyEx/FCrJ1N1QnBmraHHQNabFaeAh2IaOOLml48/rHOD1bICHgTRkbBgNTvUzEr5Z35g==
+  dependencies:
+    "@aws-sdk/types" "^3.973.12"
+    "@aws-sdk/xml-builder" "^3.972.29"
+    "@aws/lambda-invoke-store" "^0.2.2"
+    "@smithy/core" "^3.24.6"
+    "@smithy/signature-v4" "^5.4.6"
+    "@smithy/types" "^4.14.3"
+    bowser "^2.11.0"
+    tslib "^2.6.2"
+
+"@aws-sdk/credential-provider-env@^3.972.46":
+  version "3.972.46"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.46.tgz#590695585036566535b9d9f28d90658a725a123b"
+  integrity sha512-+GPXVS2srMOlH74S+SmC1gVuP2TvUZ0siuC0onKO93q+udP+M72dmY8wJfVQ5CX9z/9X5A1HHwz5yRIGBtskvQ==
+  dependencies:
+    "@aws-sdk/core" "^3.974.20"
+    "@aws-sdk/types" "^3.973.12"
+    "@smithy/core" "^3.24.6"
+    "@smithy/types" "^4.14.3"
+    tslib "^2.6.2"
+
+"@aws-sdk/credential-provider-http@^3.972.48":
+  version "3.972.48"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.48.tgz#074fe92aa255f0c42441955da6cfeb2bbc57a263"
+  integrity sha512-fA5loSdlocacRxyUXtpoHSMuk5rsIKRDzQYVMnMxjcmFeZshaJlJ8lymy/hYKji6sne/UmNGj5pxuEs6kq/Qcg==
+  dependencies:
+    "@aws-sdk/core" "^3.974.20"
+    "@aws-sdk/types" "^3.973.12"
+    "@smithy/core" "^3.24.6"
+    "@smithy/fetch-http-handler" "^5.4.6"
+    "@smithy/node-http-handler" "^4.7.6"
+    "@smithy/types" "^4.14.3"
+    tslib "^2.6.2"
+
+"@aws-sdk/credential-provider-ini@^3.972.53":
+  version "3.972.53"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.53.tgz#d17c2ebfab9c3a38c45f857567535bf4dd9290a0"
+  integrity sha512-ZfdhIOR41q8TcWEnUac+gCOb+O2LBWdHLmjedXpXz4IEFW2ppNuFcm6p0sMTavpM+zD5TYfpH5Gp7guRyqSgsQ==
+  dependencies:
+    "@aws-sdk/core" "^3.974.20"
+    "@aws-sdk/credential-provider-env" "^3.972.46"
+    "@aws-sdk/credential-provider-http" "^3.972.48"
+    "@aws-sdk/credential-provider-login" "^3.972.52"
+    "@aws-sdk/credential-provider-process" "^3.972.46"
+    "@aws-sdk/credential-provider-sso" "^3.972.52"
+    "@aws-sdk/credential-provider-web-identity" "^3.972.52"
+    "@aws-sdk/nested-clients" "^3.997.20"
+    "@aws-sdk/types" "^3.973.12"
+    "@smithy/core" "^3.24.6"
+    "@smithy/credential-provider-imds" "^4.3.7"
+    "@smithy/types" "^4.14.3"
+    tslib "^2.6.2"
+
+"@aws-sdk/credential-provider-login@^3.972.52":
+  version "3.972.52"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.52.tgz#43f2db767db000a1c5317ba35ecd2124cb0a883e"
+  integrity sha512-9hu2oR0qH7Fst5Tzdx+UWxm+w5zCXtErTLtOOW5hwwQc170CLwOeniRxyFY6s9mHfGEfC5zFukNBdKBwJR8mhQ==
+  dependencies:
+    "@aws-sdk/core" "^3.974.20"
+    "@aws-sdk/nested-clients" "^3.997.20"
+    "@aws-sdk/types" "^3.973.12"
+    "@smithy/core" "^3.24.6"
+    "@smithy/types" "^4.14.3"
+    tslib "^2.6.2"
+
+"@aws-sdk/credential-provider-node@^3.972.55":
+  version "3.972.55"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.55.tgz#117eaec668dde8e3366bdb750d4c5c247a59a31f"
+  integrity sha512-zMGLa/dhESVqmCD7mmIFFKSwSFrJGScvCXcjvBZEVOOMauFS5JRQvLTMukFpMEFWiV6dTAlsen2ATDBulLPtbg==
+  dependencies:
+    "@aws-sdk/credential-provider-env" "^3.972.46"
+    "@aws-sdk/credential-provider-http" "^3.972.48"
+    "@aws-sdk/credential-provider-ini" "^3.972.53"
+    "@aws-sdk/credential-provider-process" "^3.972.46"
+    "@aws-sdk/credential-provider-sso" "^3.972.52"
+    "@aws-sdk/credential-provider-web-identity" "^3.972.52"
+    "@aws-sdk/types" "^3.973.12"
+    "@smithy/core" "^3.24.6"
+    "@smithy/credential-provider-imds" "^4.3.7"
+    "@smithy/types" "^4.14.3"
+    tslib "^2.6.2"
+
+"@aws-sdk/credential-provider-process@^3.972.46":
+  version "3.972.46"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.46.tgz#b8d967fa7ea65bdb51a0d60609b3947f01ad1390"
+  integrity sha512-VUoNFBIjWrUN8NbFiQiuxQEgFjvziAlBRPK+ddh27aj65gk0BYu6bLZnrdrNZwpW6vAihtSUtEMQ1PUJ32QRPA==
+  dependencies:
+    "@aws-sdk/core" "^3.974.20"
+    "@aws-sdk/types" "^3.973.12"
+    "@smithy/core" "^3.24.6"
+    "@smithy/types" "^4.14.3"
+    tslib "^2.6.2"
+
+"@aws-sdk/credential-provider-sso@^3.972.52":
+  version "3.972.52"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.52.tgz#d3f43251c0a02378d9278508385f511dcc105fb8"
+  integrity sha512-nb2/n4o/HQf+FVpVbZe9vCTFngmuDoIsltMgLAtjixaKzvzhB4J8WSDFyWgnErgLHk55ctWH+I4PU+LIHhyffg==
+  dependencies:
+    "@aws-sdk/core" "^3.974.20"
+    "@aws-sdk/nested-clients" "^3.997.20"
+    "@aws-sdk/token-providers" "3.1066.0"
+    "@aws-sdk/types" "^3.973.12"
+    "@smithy/core" "^3.24.6"
+    "@smithy/types" "^4.14.3"
+    tslib "^2.6.2"
+
+"@aws-sdk/credential-provider-web-identity@^3.972.52":
+  version "3.972.52"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.52.tgz#28201a0e787f83aac75b80922d699cbe489a3d94"
+  integrity sha512-lKj6aRSGbqLmpYmM24bY7a1Xmfcq2vkE3hv8CSPYfc1yCu0BPu/XEJ1L4Fm61MsU6ULLNSG8UGsffNoFUBjESA==
+  dependencies:
+    "@aws-sdk/core" "^3.974.20"
+    "@aws-sdk/nested-clients" "^3.997.20"
+    "@aws-sdk/types" "^3.973.12"
+    "@smithy/core" "^3.24.6"
+    "@smithy/types" "^4.14.3"
+    tslib "^2.6.2"
+
+"@aws-sdk/dynamodb-codec@^3.973.20":
+  version "3.973.20"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/dynamodb-codec/-/dynamodb-codec-3.973.20.tgz#9a98587c741fa72106c5c62622d8ae63a3134cb4"
+  integrity sha512-SFfxiqVgWeIe+RsJJNAMD//2IfehT4bLpGyNJRB0MgHmOIJtdcfMnR1k7KYyaHokSoQVdncVa9O9DIGa4eqcwg==
+  dependencies:
+    "@aws-sdk/core" "^3.974.20"
+    "@smithy/core" "^3.24.6"
+    "@smithy/types" "^4.14.3"
+    tslib "^2.6.2"
+
+"@aws-sdk/endpoint-cache@^3.972.7":
+  version "3.972.7"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/endpoint-cache/-/endpoint-cache-3.972.7.tgz#aa586f465e351fb74eddf340e4f67252a9d5d80b"
+  integrity sha512-LkwS3ZOUNL5kHzmz3dDx8lE3HOhZmf2VGjbJ/tMUZJYWWl3J0RJTZM7RFz1MLt06WDVvlShcAjY/RzhYlqLL7g==
+  dependencies:
+    mnemonist "0.38.3"
+    tslib "^2.6.2"
+
+"@aws-sdk/lib-dynamodb@^3.0.0":
+  version "3.1068.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/lib-dynamodb/-/lib-dynamodb-3.1068.0.tgz#bfb1651ff834f2d2f2280feba18cd1a02a4d27ec"
+  integrity sha512-r3ChLc59RYNDfenMm+7GJ23zKRzTG+b3nAUgHt9XOKOCaJ3c203DzkY/m5yNslAhZ1r0ArxDaecd8rqioDXRuQ==
+  dependencies:
+    "@aws-sdk/core" "^3.974.20"
+    "@aws-sdk/util-dynamodb" "^3.996.4"
+    "@smithy/core" "^3.24.6"
+    "@smithy/types" "^4.14.3"
+    tslib "^2.6.2"
+
+"@aws-sdk/middleware-endpoint-discovery@^3.972.18":
+  version "3.972.18"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-endpoint-discovery/-/middleware-endpoint-discovery-3.972.18.tgz#226d974c1ad33c18fbc2b34ba689af26cf8a86e5"
+  integrity sha512-1vKJt/6MBB/MBMRM3qzCMdW70syJY8u2DH+dq7yCnPn7wVJmyeAzAa/sK1lIbbYh8BVLbM5FspsT4zbe885gOw==
+  dependencies:
+    "@aws-sdk/endpoint-cache" "^3.972.7"
+    "@aws-sdk/types" "^3.973.12"
+    "@smithy/core" "^3.24.6"
+    "@smithy/types" "^4.14.3"
+    tslib "^2.6.2"
+
+"@aws-sdk/nested-clients@^3.997.20":
+  version "3.997.20"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/nested-clients/-/nested-clients-3.997.20.tgz#00607f294f0109c1ee96cccab411106b8fa55625"
+  integrity sha512-IYJuLpXp2DEILVQpQOy0PMpkftv0AHEOCn52o0atyOaumA0CdWQ3klPyXdViGYLbNpESsVFMVybvHUeZAuiGxA==
+  dependencies:
+    "@aws-crypto/sha256-browser" "5.2.0"
+    "@aws-crypto/sha256-js" "5.2.0"
+    "@aws-sdk/core" "^3.974.20"
+    "@aws-sdk/signature-v4-multi-region" "^3.996.34"
+    "@aws-sdk/types" "^3.973.12"
+    "@smithy/core" "^3.24.6"
+    "@smithy/fetch-http-handler" "^5.4.6"
+    "@smithy/node-http-handler" "^4.7.6"
+    "@smithy/types" "^4.14.3"
+    tslib "^2.6.2"
+
+"@aws-sdk/signature-v4-multi-region@^3.996.34":
+  version "3.996.34"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.34.tgz#99749163def9dfc720eef85f7fe2d14bb4b763fb"
+  integrity sha512-mx1L5qlumSOt/nKM3BFaHE2HVkWwz0i4Bw0pyYO42FfX/FeLlo8YI6csC0gSPprEk6fTIqI+CZN9RwUwKd5krQ==
+  dependencies:
+    "@aws-sdk/types" "^3.973.12"
+    "@smithy/signature-v4" "^5.4.6"
+    "@smithy/types" "^4.14.3"
+    tslib "^2.6.2"
+
+"@aws-sdk/token-providers@3.1066.0":
+  version "3.1066.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/token-providers/-/token-providers-3.1066.0.tgz#1253c27ab45284655ab935411a0fbbf91b2c7c7f"
+  integrity sha512-UqEUJq7dqa44hneLDUcX7UJy95cg8YqEWyakRpvIPnrNS3Mq+UlQHgCDGu5pvwAPtlIW4qcYbvW6reG6++FyvA==
+  dependencies:
+    "@aws-sdk/core" "^3.974.20"
+    "@aws-sdk/nested-clients" "^3.997.20"
+    "@aws-sdk/types" "^3.973.12"
+    "@smithy/core" "^3.24.6"
+    "@smithy/types" "^4.14.3"
+    tslib "^2.6.2"
+
+"@aws-sdk/types@^3.222.0", "@aws-sdk/types@^3.973.12":
+  version "3.973.12"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/types/-/types-3.973.12.tgz#a3ae50d325644e4e890030d187febbeef2d238ef"
+  integrity sha512-43ajd1NF0RMgX5k0hxCNUyEdrtFUsb2aHT2QvpktSC/2Eyb2Jr/JPVqdp0XIoaHWikZJq5tNWSLO6kB5q2eMCA==
+  dependencies:
+    "@smithy/types" "^4.14.3"
+    tslib "^2.6.2"
+
+"@aws-sdk/util-dynamodb@^3.996.4":
+  version "3.996.4"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/util-dynamodb/-/util-dynamodb-3.996.4.tgz#577a5ca1b8563b03fb9fa753fa7d3060d045c395"
+  integrity sha512-Gel6Qiof4NWdtGT548FxoAkmmKmvsEVQYzbtC4RJnwgh9z33gmiYSJOGnKZHvZJWC2SgjS6AKe6DfuGCqU4vdg==
+  dependencies:
+    tslib "^2.6.2"
+
+"@aws-sdk/util-locate-window@^3.0.0":
+  version "3.965.7"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/util-locate-window/-/util-locate-window-3.965.7.tgz#dc527d5405b7eb3dc5699071d51c9f9afc874fe0"
+  integrity sha512-M0D6oIpohdNHjc7udzTHEQyot0+0iuA36jc2I9Hps+f/GtKi2HO/pyijQnCnNcwZqLB5+rtn81z3eZK/GyjAmA==
+  dependencies:
+    tslib "^2.6.2"
+
+"@aws-sdk/xml-builder@^3.972.29":
+  version "3.972.29"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/xml-builder/-/xml-builder-3.972.29.tgz#1fffe1dd3fbb84c034ff2f8008de8a6926a4a672"
+  integrity sha512-fk0niuGFxfi8yIJuMVM4mhwObkiQSuwZFj3tAPrLVx64Pk3BkrEIpqjzHKY4hKoEBUD6Jg/S74Zj9jy+5F3DnQ==
+  dependencies:
+    "@smithy/types" "^4.14.3"
+    fast-xml-parser "5.7.3"
+    tslib "^2.6.2"
+
+"@aws/lambda-invoke-store@^0.2.2":
+  version "0.2.4"
+  resolved "https://registry.yarnpkg.com/@aws/lambda-invoke-store/-/lambda-invoke-store-0.2.4.tgz#802f6a50f6b6589063ef63ba8acdee86fcb9f395"
+  integrity sha512-iY8yvjE0y651BixKNPgmv1WrQc+GZ142sb0z4gYnChDDY2YqI4P/jsSopBWrKfAt7LOJAkOXt7rC/hms+WclQQ==
+
 "@babel/code-frame@^7.0.0", "@babel/code-frame@^7.12.13", "@babel/code-frame@^7.14.5":
   version "7.14.5"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.14.5.tgz#23b08d740e83f49c5e59945fbf1b43e80bbf4edb"
@@ -9,33 +327,53 @@
   dependencies:
     "@babel/highlight" "^7.14.5"
 
-"@babel/compat-data@^7.14.5":
-  version "7.14.7"
-  resolved "https://registry.yarnpkg.com/@babel/compat-data/-/compat-data-7.14.7.tgz#7b047d7a3a89a67d2258dc61f604f098f1bc7e08"
-  integrity sha512-nS6dZaISCXJ3+518CWiBfEr//gHyMO02uDxBkXTKZDN5POruCnOZ1N4YBRZDCabwF8nZMWBpRxIicmXtBs+fvw==
-
-"@babel/core@^7.1.0", "@babel/core@^7.7.2", "@babel/core@^7.7.5":
-  version "7.14.6"
-  resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.14.6.tgz#e0814ec1a950032ff16c13a2721de39a8416fcab"
-  integrity sha512-gJnOEWSqTk96qG5BoIrl5bVtc23DCycmIePPYnamY9RboYdI4nFy5vAQMSl81O5K/W0sLDWfGysnOECC+KUUCA==
+"@babel/code-frame@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.29.7.tgz#f2fbbfea87c44a21590ec515b778b2c26d8866e7"
+  integrity sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==
   dependencies:
-    "@babel/code-frame" "^7.14.5"
-    "@babel/generator" "^7.14.5"
-    "@babel/helper-compilation-targets" "^7.14.5"
-    "@babel/helper-module-transforms" "^7.14.5"
-    "@babel/helpers" "^7.14.6"
-    "@babel/parser" "^7.14.6"
-    "@babel/template" "^7.14.5"
-    "@babel/traverse" "^7.14.5"
-    "@babel/types" "^7.14.5"
-    convert-source-map "^1.7.0"
+    "@babel/helper-validator-identifier" "^7.29.7"
+    js-tokens "^4.0.0"
+    picocolors "^1.1.1"
+
+"@babel/compat-data@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/compat-data/-/compat-data-7.29.7.tgz#6f0237f0f36d2e51c0570a636faed9d2d0efe629"
+  integrity sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==
+
+"@babel/core@^7.11.6", "@babel/core@^7.12.3", "@babel/core@^7.23.9":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.29.7.tgz#80c10b17248082968b57a857b91640971f2070f7"
+  integrity sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==
+  dependencies:
+    "@babel/code-frame" "^7.29.7"
+    "@babel/generator" "^7.29.7"
+    "@babel/helper-compilation-targets" "^7.29.7"
+    "@babel/helper-module-transforms" "^7.29.7"
+    "@babel/helpers" "^7.29.7"
+    "@babel/parser" "^7.29.7"
+    "@babel/template" "^7.29.7"
+    "@babel/traverse" "^7.29.7"
+    "@babel/types" "^7.29.7"
+    "@jridgewell/remapping" "^2.3.5"
+    convert-source-map "^2.0.0"
     debug "^4.1.0"
     gensync "^1.0.0-beta.2"
-    json5 "^2.1.2"
-    semver "^6.3.0"
-    source-map "^0.5.0"
+    json5 "^2.2.3"
+    semver "^6.3.1"
 
-"@babel/generator@^7.14.5", "@babel/generator@^7.7.2":
+"@babel/generator@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.29.7.tgz#cca0b8827e6bcf3ba176788e7f3b180ad6db2fa3"
+  integrity sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==
+  dependencies:
+    "@babel/parser" "^7.29.7"
+    "@babel/types" "^7.29.7"
+    "@jridgewell/gen-mapping" "^0.3.12"
+    "@jridgewell/trace-mapping" "^0.3.28"
+    jsesc "^3.0.2"
+
+"@babel/generator@^7.7.2":
   version "7.14.5"
   resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.14.5.tgz#848d7b9f031caca9d0cd0af01b063f226f52d785"
   integrity sha512-y3rlP+/G25OIX3mYKKIOlQRcqj7YgrvHxOLbVmyLJ9bPmi5ttvUmpydVjcFjZphOktWuA7ovbx91ECloWTfjIA==
@@ -44,121 +382,76 @@
     jsesc "^2.5.1"
     source-map "^0.5.0"
 
-"@babel/helper-compilation-targets@^7.14.5":
-  version "7.14.5"
-  resolved "https://registry.yarnpkg.com/@babel/helper-compilation-targets/-/helper-compilation-targets-7.14.5.tgz#7a99c5d0967911e972fe2c3411f7d5b498498ecf"
-  integrity sha512-v+QtZqXEiOnpO6EYvlImB6zCD2Lel06RzOPzmkz/D/XgQiUu3C/Jb1LOqSt/AIA34TYi/Q+KlT8vTQrgdxkbLw==
+"@babel/helper-compilation-targets@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz#7a1def704302401c47f64fa85589e974ae217042"
+  integrity sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==
   dependencies:
-    "@babel/compat-data" "^7.14.5"
-    "@babel/helper-validator-option" "^7.14.5"
-    browserslist "^4.16.6"
-    semver "^6.3.0"
+    "@babel/compat-data" "^7.29.7"
+    "@babel/helper-validator-option" "^7.29.7"
+    browserslist "^4.24.0"
+    lru-cache "^5.1.1"
+    semver "^6.3.1"
 
-"@babel/helper-function-name@^7.14.5":
-  version "7.14.5"
-  resolved "https://registry.yarnpkg.com/@babel/helper-function-name/-/helper-function-name-7.14.5.tgz#89e2c474972f15d8e233b52ee8c480e2cfcd50c4"
-  integrity sha512-Gjna0AsXWfFvrAuX+VKcN/aNNWonizBj39yGwUzVDVTlMYJMK2Wp6xdpy72mfArFq5uK+NOuexfzZlzI1z9+AQ==
-  dependencies:
-    "@babel/helper-get-function-arity" "^7.14.5"
-    "@babel/template" "^7.14.5"
-    "@babel/types" "^7.14.5"
+"@babel/helper-globals@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/helper-globals/-/helper-globals-7.29.7.tgz#f04a96fbd8473241b1079243f5b3f03a3010ab7b"
+  integrity sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==
 
-"@babel/helper-get-function-arity@^7.14.5":
-  version "7.14.5"
-  resolved "https://registry.yarnpkg.com/@babel/helper-get-function-arity/-/helper-get-function-arity-7.14.5.tgz#25fbfa579b0937eee1f3b805ece4ce398c431815"
-  integrity sha512-I1Db4Shst5lewOM4V+ZKJzQ0JGGaZ6VY1jYvMghRjqs6DWgxLCIyFt30GlnKkfUeFLpJt2vzbMVEXVSXlIFYUg==
+"@babel/helper-module-imports@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz#ef25048a518e828d7393fac5882ddd73921d7396"
+  integrity sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==
   dependencies:
-    "@babel/types" "^7.14.5"
+    "@babel/traverse" "^7.29.7"
+    "@babel/types" "^7.29.7"
 
-"@babel/helper-hoist-variables@^7.14.5":
-  version "7.14.5"
-  resolved "https://registry.yarnpkg.com/@babel/helper-hoist-variables/-/helper-hoist-variables-7.14.5.tgz#e0dd27c33a78e577d7c8884916a3e7ef1f7c7f8d"
-  integrity sha512-R1PXiz31Uc0Vxy4OEOm07x0oSjKAdPPCh3tPivn/Eo8cvz6gveAeuyUUPB21Hoiif0uoPQSSdhIPS3352nvdyQ==
+"@babel/helper-module-transforms@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz#b062747a5997ba138637201328bbff77960574ae"
+  integrity sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==
   dependencies:
-    "@babel/types" "^7.14.5"
-
-"@babel/helper-member-expression-to-functions@^7.14.5":
-  version "7.14.7"
-  resolved "https://registry.yarnpkg.com/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.14.7.tgz#97e56244beb94211fe277bd818e3a329c66f7970"
-  integrity sha512-TMUt4xKxJn6ccjcOW7c4hlwyJArizskAhoSTOCkA0uZ+KghIaci0Qg9R043kUMWI9mtQfgny+NQ5QATnZ+paaA==
-  dependencies:
-    "@babel/types" "^7.14.5"
-
-"@babel/helper-module-imports@^7.14.5":
-  version "7.14.5"
-  resolved "https://registry.yarnpkg.com/@babel/helper-module-imports/-/helper-module-imports-7.14.5.tgz#6d1a44df6a38c957aa7c312da076429f11b422f3"
-  integrity sha512-SwrNHu5QWS84XlHwGYPDtCxcA0hrSlL2yhWYLgeOc0w7ccOl2qv4s/nARI0aYZW+bSwAL5CukeXA47B/1NKcnQ==
-  dependencies:
-    "@babel/types" "^7.14.5"
-
-"@babel/helper-module-transforms@^7.14.5":
-  version "7.14.5"
-  resolved "https://registry.yarnpkg.com/@babel/helper-module-transforms/-/helper-module-transforms-7.14.5.tgz#7de42f10d789b423eb902ebd24031ca77cb1e10e"
-  integrity sha512-iXpX4KW8LVODuAieD7MzhNjmM6dzYY5tfRqT+R9HDXWl0jPn/djKmA+G9s/2C2T9zggw5tK1QNqZ70USfedOwA==
-  dependencies:
-    "@babel/helper-module-imports" "^7.14.5"
-    "@babel/helper-replace-supers" "^7.14.5"
-    "@babel/helper-simple-access" "^7.14.5"
-    "@babel/helper-split-export-declaration" "^7.14.5"
-    "@babel/helper-validator-identifier" "^7.14.5"
-    "@babel/template" "^7.14.5"
-    "@babel/traverse" "^7.14.5"
-    "@babel/types" "^7.14.5"
-
-"@babel/helper-optimise-call-expression@^7.14.5":
-  version "7.14.5"
-  resolved "https://registry.yarnpkg.com/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.14.5.tgz#f27395a8619e0665b3f0364cddb41c25d71b499c"
-  integrity sha512-IqiLIrODUOdnPU9/F8ib1Fx2ohlgDhxnIDU7OEVi+kAbEZcyiF7BLU8W6PfvPi9LzztjS7kcbzbmL7oG8kD6VA==
-  dependencies:
-    "@babel/types" "^7.14.5"
+    "@babel/helper-module-imports" "^7.29.7"
+    "@babel/helper-validator-identifier" "^7.29.7"
+    "@babel/traverse" "^7.29.7"
 
 "@babel/helper-plugin-utils@^7.0.0", "@babel/helper-plugin-utils@^7.10.4", "@babel/helper-plugin-utils@^7.12.13", "@babel/helper-plugin-utils@^7.14.5", "@babel/helper-plugin-utils@^7.8.0":
   version "7.14.5"
   resolved "https://registry.yarnpkg.com/@babel/helper-plugin-utils/-/helper-plugin-utils-7.14.5.tgz#5ac822ce97eec46741ab70a517971e443a70c5a9"
   integrity sha512-/37qQCE3K0vvZKwoK4XU/irIJQdIfCJuhU5eKnNxpFDsOkgFaUAwbv+RYw6eYgsC0E4hS7r5KqGULUogqui0fQ==
 
-"@babel/helper-replace-supers@^7.14.5":
-  version "7.14.5"
-  resolved "https://registry.yarnpkg.com/@babel/helper-replace-supers/-/helper-replace-supers-7.14.5.tgz#0ecc0b03c41cd567b4024ea016134c28414abb94"
-  integrity sha512-3i1Qe9/8x/hCHINujn+iuHy+mMRLoc77b2nI9TB0zjH1hvn9qGlXjWlggdwUcju36PkPCy/lpM7LLUdcTyH4Ow==
-  dependencies:
-    "@babel/helper-member-expression-to-functions" "^7.14.5"
-    "@babel/helper-optimise-call-expression" "^7.14.5"
-    "@babel/traverse" "^7.14.5"
-    "@babel/types" "^7.14.5"
+"@babel/helper-plugin-utils@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/helper-plugin-utils/-/helper-plugin-utils-7.29.7.tgz#c0a0766f1a13617d8a17407d7ab8f9d486225ea4"
+  integrity sha512-G7sHYigPY17oO5SYWnfD/0MTBwVR781S/JI643e/JhUYgVgWE/61SoW3NH9KWUKyKq5LVh3npif99Wkt6j86Jw==
 
-"@babel/helper-simple-access@^7.14.5":
-  version "7.14.5"
-  resolved "https://registry.yarnpkg.com/@babel/helper-simple-access/-/helper-simple-access-7.14.5.tgz#66ea85cf53ba0b4e588ba77fc813f53abcaa41c4"
-  integrity sha512-nfBN9xvmCt6nrMZjfhkl7i0oTV3yxR4/FztsbOASyTvVcoYd0TRHh7eMLdlEcCqobydC0LAF3LtC92Iwxo0wyw==
-  dependencies:
-    "@babel/types" "^7.14.5"
-
-"@babel/helper-split-export-declaration@^7.14.5":
-  version "7.14.5"
-  resolved "https://registry.yarnpkg.com/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.14.5.tgz#22b23a54ef51c2b7605d851930c1976dd0bc693a"
-  integrity sha512-hprxVPu6e5Kdp2puZUmvOGjaLv9TCe58E/Fl6hRq4YiVQxIcNvuq6uTM2r1mT/oPskuS9CgR+I94sqAYv0NGKA==
-  dependencies:
-    "@babel/types" "^7.14.5"
+"@babel/helper-string-parser@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz#7f0871d99824d23137d60f86fcf6130fd5a1b51f"
+  integrity sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==
 
 "@babel/helper-validator-identifier@^7.14.5":
   version "7.14.5"
   resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.5.tgz#d0f0e277c512e0c938277faa85a3968c9a44c0e8"
   integrity sha512-5lsetuxCLilmVGyiLEfoHBRX8UCFD+1m2x3Rj97WrW3V7H3u4RWRXA4evMjImCsin2J2YT0QaVDGf+z8ondbAg==
 
-"@babel/helper-validator-option@^7.14.5":
-  version "7.14.5"
-  resolved "https://registry.yarnpkg.com/@babel/helper-validator-option/-/helper-validator-option-7.14.5.tgz#6e72a1fff18d5dfcb878e1e62f1a021c4b72d5a3"
-  integrity sha512-OX8D5eeX4XwcroVW45NMvoYaIuFI+GQpA2a8Gi+X/U/cDUIRsV37qQfF905F0htTRCREQIB4KqPeaveRJUl3Ow==
+"@babel/helper-validator-identifier@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz#bd87084ced0c796ec46bda492de6e83d29e89fc2"
+  integrity sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==
 
-"@babel/helpers@^7.14.6":
-  version "7.14.6"
-  resolved "https://registry.yarnpkg.com/@babel/helpers/-/helpers-7.14.6.tgz#5b58306b95f1b47e2a0199434fa8658fa6c21635"
-  integrity sha512-yesp1ENQBiLI+iYHSJdoZKUtRpfTlL1grDIX9NRlAVppljLw/4tTyYupIB7uIYmC3stW/imAv8EqaKaS/ibmeA==
+"@babel/helper-validator-option@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz#cf315be940213b354eb4abcc0bd01ebe3f73bc2a"
+  integrity sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==
+
+"@babel/helpers@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/helpers/-/helpers-7.29.7.tgz#45abfde7548997e34376c3e69feb475cffb4a607"
+  integrity sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==
   dependencies:
-    "@babel/template" "^7.14.5"
-    "@babel/traverse" "^7.14.5"
-    "@babel/types" "^7.14.5"
+    "@babel/template" "^7.29.7"
+    "@babel/types" "^7.29.7"
 
 "@babel/highlight@^7.14.5":
   version "7.14.5"
@@ -169,10 +462,17 @@
     chalk "^2.0.0"
     js-tokens "^4.0.0"
 
-"@babel/parser@^7.1.0", "@babel/parser@^7.14.5", "@babel/parser@^7.14.6", "@babel/parser@^7.14.7", "@babel/parser@^7.7.2":
+"@babel/parser@^7.1.0", "@babel/parser@^7.14.5", "@babel/parser@^7.14.7":
   version "7.14.7"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.14.7.tgz#6099720c8839ca865a2637e6c85852ead0bdb595"
   integrity sha512-X67Z5y+VBJuHB/RjwECp8kSl5uYi0BvRbNeWqkaJCVh+LiTPl19WBUfG627psSgp9rSf6ojuXghQM3ha6qHHdA==
+
+"@babel/parser@^7.23.9", "@babel/parser@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.29.7.tgz#837b87387cbf5ec5530cb634b3c622f68edb9334"
+  integrity sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==
+  dependencies:
+    "@babel/types" "^7.29.7"
 
 "@babel/plugin-syntax-async-generators@^7.8.4":
   version "7.8.4"
@@ -208,6 +508,13 @@
   integrity sha512-lY6kdGpWHvjoe2vk4WrAapEuBR69EMxZl+RoGRhrFGNYVK8mOPAW8VfbT/ZgrFbXlDNiiaxQnAtgVCZ6jv30EA==
   dependencies:
     "@babel/helper-plugin-utils" "^7.8.0"
+
+"@babel/plugin-syntax-jsx@^7.7.2":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.29.7.tgz#622c16f9ad63782fe6e83dadc7e40330744b7f1e"
+  integrity sha512-TSu8+mHCoEaaCDEZ0I3+6mvTBYR4PCxQwf2z9/r5Tbztv6NaLR3B9thGTTxX2WGuGHJqRiAbKPeGTJ5XWXVg6A==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.29.7"
 
 "@babel/plugin-syntax-logical-assignment-operators@^7.8.3":
   version "7.10.4"
@@ -272,7 +579,16 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
-"@babel/template@^7.14.5", "@babel/template@^7.3.3":
+"@babel/template@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.29.7.tgz#4d9d4004f645cdd304de958c725162784ecac700"
+  integrity sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==
+  dependencies:
+    "@babel/code-frame" "^7.29.7"
+    "@babel/parser" "^7.29.7"
+    "@babel/types" "^7.29.7"
+
+"@babel/template@^7.3.3":
   version "7.14.5"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.14.5.tgz#a9bc9d8b33354ff6e55a9c60d1109200a68974f4"
   integrity sha512-6Z3Po85sfxRGachLULUhOmvAaOo7xCvqGQtxINai2mEGPFm6pQ4z5QInFnUrRpfoSV60BnjyF5F3c+15fxFV1g==
@@ -281,20 +597,18 @@
     "@babel/parser" "^7.14.5"
     "@babel/types" "^7.14.5"
 
-"@babel/traverse@^7.1.0", "@babel/traverse@^7.14.5", "@babel/traverse@^7.7.2":
-  version "7.14.7"
-  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.14.7.tgz#64007c9774cfdc3abd23b0780bc18a3ce3631753"
-  integrity sha512-9vDr5NzHu27wgwejuKL7kIOm4bwEtaPQ4Z6cpCmjSuaRqpH/7xc4qcGEscwMqlkwgcXl6MvqoAjZkQ24uSdIZQ==
+"@babel/traverse@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.29.7.tgz#c47b07a41b95da0907d026b5dd894d98de7d2f2d"
+  integrity sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==
   dependencies:
-    "@babel/code-frame" "^7.14.5"
-    "@babel/generator" "^7.14.5"
-    "@babel/helper-function-name" "^7.14.5"
-    "@babel/helper-hoist-variables" "^7.14.5"
-    "@babel/helper-split-export-declaration" "^7.14.5"
-    "@babel/parser" "^7.14.7"
-    "@babel/types" "^7.14.5"
-    debug "^4.1.0"
-    globals "^11.1.0"
+    "@babel/code-frame" "^7.29.7"
+    "@babel/generator" "^7.29.7"
+    "@babel/helper-globals" "^7.29.7"
+    "@babel/parser" "^7.29.7"
+    "@babel/template" "^7.29.7"
+    "@babel/types" "^7.29.7"
+    debug "^4.3.1"
 
 "@babel/types@^7.0.0", "@babel/types@^7.14.5", "@babel/types@^7.3.0", "@babel/types@^7.3.3":
   version "7.14.5"
@@ -303,6 +617,14 @@
   dependencies:
     "@babel/helper-validator-identifier" "^7.14.5"
     to-fast-properties "^2.0.0"
+
+"@babel/types@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.29.7.tgz#8005e31d82712ee7adaef6e23c63b71a62770a92"
+  integrity sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==
+  dependencies:
+    "@babel/helper-string-parser" "^7.29.7"
+    "@babel/helper-validator-identifier" "^7.29.7"
 
 "@bcoe/v8-coverage@^0.2.3":
   version "0.2.3"
@@ -517,163 +839,190 @@
   resolved "https://registry.yarnpkg.com/@istanbuljs/schema/-/schema-0.1.3.tgz#e45e384e4b8ec16bce2fd903af78450f6bf7ec98"
   integrity sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==
 
-"@jest/console@^27.0.6":
-  version "27.0.6"
-  resolved "https://registry.yarnpkg.com/@jest/console/-/console-27.0.6.tgz#3eb72ea80897495c3d73dd97aab7f26770e2260f"
-  integrity sha512-fMlIBocSHPZ3JxgWiDNW/KPj6s+YRd0hicb33IrmelCcjXo/pXPwvuiKFmZz+XuqI/1u7nbUK10zSsWL/1aegg==
+"@istanbuljs/schema@^0.1.3":
+  version "0.1.6"
+  resolved "https://registry.yarnpkg.com/@istanbuljs/schema/-/schema-0.1.6.tgz#8dc9afa2ac1506cb1a58f89940f1c124446c8df3"
+  integrity sha512-+Sg6GCR/wy1oSmQDFq4LQDAhm3ETKnorxN+y5nbLULOR3P0c14f2Wurzj3/xqPXtasLFfHd5iRFQ7AJt4KH2cw==
+
+"@jest/console@^29.7.0":
+  version "29.7.0"
+  resolved "https://registry.yarnpkg.com/@jest/console/-/console-29.7.0.tgz#cd4822dbdb84529265c5a2bdb529a3c9cc950ffc"
+  integrity sha512-5Ni4CU7XHQi32IJ398EEP4RrB8eV09sXP2ROqD4bksHrnTree52PsxvX8tpL8LvTZ3pFzXyPbNQReSN41CAhOg==
   dependencies:
-    "@jest/types" "^27.0.6"
+    "@jest/types" "^29.6.3"
     "@types/node" "*"
     chalk "^4.0.0"
-    jest-message-util "^27.0.6"
-    jest-util "^27.0.6"
+    jest-message-util "^29.7.0"
+    jest-util "^29.7.0"
     slash "^3.0.0"
 
-"@jest/core@^27.0.4", "@jest/core@^27.0.6":
-  version "27.0.6"
-  resolved "https://registry.yarnpkg.com/@jest/core/-/core-27.0.6.tgz#c5f642727a0b3bf0f37c4b46c675372d0978d4a1"
-  integrity sha512-SsYBm3yhqOn5ZLJCtccaBcvD/ccTLCeuDv8U41WJH/V1MW5eKUkeMHT9U+Pw/v1m1AIWlnIW/eM2XzQr0rEmow==
+"@jest/core@^29.7.0":
+  version "29.7.0"
+  resolved "https://registry.yarnpkg.com/@jest/core/-/core-29.7.0.tgz#b6cccc239f30ff36609658c5a5e2291757ce448f"
+  integrity sha512-n7aeXWKMnGtDA48y8TLWJPJmLmmZ642Ceo78cYWEpiD7FzDgmNDV/GCVRorPABdXLJZ/9wzzgZAlHjXjxDHGsg==
   dependencies:
-    "@jest/console" "^27.0.6"
-    "@jest/reporters" "^27.0.6"
-    "@jest/test-result" "^27.0.6"
-    "@jest/transform" "^27.0.6"
-    "@jest/types" "^27.0.6"
+    "@jest/console" "^29.7.0"
+    "@jest/reporters" "^29.7.0"
+    "@jest/test-result" "^29.7.0"
+    "@jest/transform" "^29.7.0"
+    "@jest/types" "^29.6.3"
     "@types/node" "*"
     ansi-escapes "^4.2.1"
     chalk "^4.0.0"
-    emittery "^0.8.1"
+    ci-info "^3.2.0"
     exit "^0.1.2"
-    graceful-fs "^4.2.4"
-    jest-changed-files "^27.0.6"
-    jest-config "^27.0.6"
-    jest-haste-map "^27.0.6"
-    jest-message-util "^27.0.6"
-    jest-regex-util "^27.0.6"
-    jest-resolve "^27.0.6"
-    jest-resolve-dependencies "^27.0.6"
-    jest-runner "^27.0.6"
-    jest-runtime "^27.0.6"
-    jest-snapshot "^27.0.6"
-    jest-util "^27.0.6"
-    jest-validate "^27.0.6"
-    jest-watcher "^27.0.6"
+    graceful-fs "^4.2.9"
+    jest-changed-files "^29.7.0"
+    jest-config "^29.7.0"
+    jest-haste-map "^29.7.0"
+    jest-message-util "^29.7.0"
+    jest-regex-util "^29.6.3"
+    jest-resolve "^29.7.0"
+    jest-resolve-dependencies "^29.7.0"
+    jest-runner "^29.7.0"
+    jest-runtime "^29.7.0"
+    jest-snapshot "^29.7.0"
+    jest-util "^29.7.0"
+    jest-validate "^29.7.0"
+    jest-watcher "^29.7.0"
     micromatch "^4.0.4"
-    p-each-series "^2.1.0"
-    rimraf "^3.0.0"
+    pretty-format "^29.7.0"
     slash "^3.0.0"
     strip-ansi "^6.0.0"
 
-"@jest/environment@^27.0.6":
-  version "27.0.6"
-  resolved "https://registry.yarnpkg.com/@jest/environment/-/environment-27.0.6.tgz#ee293fe996db01d7d663b8108fa0e1ff436219d2"
-  integrity sha512-4XywtdhwZwCpPJ/qfAkqExRsERW+UaoSRStSHCCiQTUpoYdLukj+YJbQSFrZjhlUDRZeNiU9SFH0u7iNimdiIg==
+"@jest/environment@^29.7.0":
+  version "29.7.0"
+  resolved "https://registry.yarnpkg.com/@jest/environment/-/environment-29.7.0.tgz#24d61f54ff1f786f3cd4073b4b94416383baf2a7"
+  integrity sha512-aQIfHDq33ExsN4jP1NWGXhxgQ/wixs60gDiKO+XVMd8Mn0NWPWgc34ZQDTb2jKaUWQ7MuwoitXAsN2XVXNMpAw==
   dependencies:
-    "@jest/fake-timers" "^27.0.6"
-    "@jest/types" "^27.0.6"
+    "@jest/fake-timers" "^29.7.0"
+    "@jest/types" "^29.6.3"
     "@types/node" "*"
-    jest-mock "^27.0.6"
+    jest-mock "^29.7.0"
 
-"@jest/fake-timers@^27.0.6":
-  version "27.0.6"
-  resolved "https://registry.yarnpkg.com/@jest/fake-timers/-/fake-timers-27.0.6.tgz#cbad52f3fe6abe30e7acb8cd5fa3466b9588e3df"
-  integrity sha512-sqd+xTWtZ94l3yWDKnRTdvTeZ+A/V7SSKrxsrOKSqdyddb9CeNRF8fbhAU0D7ZJBpTTW2nbp6MftmKJDZfW2LQ==
+"@jest/expect-utils@^29.7.0":
+  version "29.7.0"
+  resolved "https://registry.yarnpkg.com/@jest/expect-utils/-/expect-utils-29.7.0.tgz#023efe5d26a8a70f21677d0a1afc0f0a44e3a1c6"
+  integrity sha512-GlsNBWiFQFCVi9QVSx7f5AgMeLxe9YCCs5PuP2O2LdjDAA8Jh9eX7lA1Jq/xdXw3Wb3hyvlFNfZIfcRetSzYcA==
   dependencies:
-    "@jest/types" "^27.0.6"
-    "@sinonjs/fake-timers" "^7.0.2"
+    jest-get-type "^29.6.3"
+
+"@jest/expect@^29.7.0":
+  version "29.7.0"
+  resolved "https://registry.yarnpkg.com/@jest/expect/-/expect-29.7.0.tgz#76a3edb0cb753b70dfbfe23283510d3d45432bf2"
+  integrity sha512-8uMeAMycttpva3P1lBHB8VciS9V0XAr3GymPpipdyQXbBcuhkLQOSe8E/p92RyAdToS6ZD1tFkX+CkhoECE0dQ==
+  dependencies:
+    expect "^29.7.0"
+    jest-snapshot "^29.7.0"
+
+"@jest/fake-timers@^29.7.0":
+  version "29.7.0"
+  resolved "https://registry.yarnpkg.com/@jest/fake-timers/-/fake-timers-29.7.0.tgz#fd91bf1fffb16d7d0d24a426ab1a47a49881a565"
+  integrity sha512-q4DH1Ha4TTFPdxLsqDXK1d3+ioSL7yL5oCMJZgDYm6i+6CygW5E5xVr/D1HdsGxjt1ZWSfUAs9OxSB/BNelWrQ==
+  dependencies:
+    "@jest/types" "^29.6.3"
+    "@sinonjs/fake-timers" "^10.0.2"
     "@types/node" "*"
-    jest-message-util "^27.0.6"
-    jest-mock "^27.0.6"
-    jest-util "^27.0.6"
+    jest-message-util "^29.7.0"
+    jest-mock "^29.7.0"
+    jest-util "^29.7.0"
 
-"@jest/globals@^27.0.6":
-  version "27.0.6"
-  resolved "https://registry.yarnpkg.com/@jest/globals/-/globals-27.0.6.tgz#48e3903f99a4650673d8657334d13c9caf0e8f82"
-  integrity sha512-DdTGCP606rh9bjkdQ7VvChV18iS7q0IMJVP1piwTWyWskol4iqcVwthZmoJEf7obE1nc34OpIyoVGPeqLC+ryw==
+"@jest/globals@^29.7.0":
+  version "29.7.0"
+  resolved "https://registry.yarnpkg.com/@jest/globals/-/globals-29.7.0.tgz#8d9290f9ec47ff772607fa864ca1d5a2efae1d4d"
+  integrity sha512-mpiz3dutLbkW2MNFubUGUEVLkTGiqW6yLVTA+JbP6fI6J5iL9Y0Nlg8k95pcF8ctKwCS7WVxteBs29hhfAotzQ==
   dependencies:
-    "@jest/environment" "^27.0.6"
-    "@jest/types" "^27.0.6"
-    expect "^27.0.6"
+    "@jest/environment" "^29.7.0"
+    "@jest/expect" "^29.7.0"
+    "@jest/types" "^29.6.3"
+    jest-mock "^29.7.0"
 
-"@jest/reporters@^27.0.6":
-  version "27.0.6"
-  resolved "https://registry.yarnpkg.com/@jest/reporters/-/reporters-27.0.6.tgz#91e7f2d98c002ad5df94d5b5167c1eb0b9fd5b00"
-  integrity sha512-TIkBt09Cb2gptji3yJXb3EE+eVltW6BjO7frO7NEfjI9vSIYoISi5R3aI3KpEDXlB1xwB+97NXIqz84qYeYsfA==
+"@jest/reporters@^29.7.0":
+  version "29.7.0"
+  resolved "https://registry.yarnpkg.com/@jest/reporters/-/reporters-29.7.0.tgz#04b262ecb3b8faa83b0b3d321623972393e8f4c7"
+  integrity sha512-DApq0KJbJOEzAFYjHADNNxAE3KbhxQB1y5Kplb5Waqw6zVbuWatSnMjE5gs8FUgEPmNsnZA3NCWl9NG0ia04Pg==
   dependencies:
     "@bcoe/v8-coverage" "^0.2.3"
-    "@jest/console" "^27.0.6"
-    "@jest/test-result" "^27.0.6"
-    "@jest/transform" "^27.0.6"
-    "@jest/types" "^27.0.6"
+    "@jest/console" "^29.7.0"
+    "@jest/test-result" "^29.7.0"
+    "@jest/transform" "^29.7.0"
+    "@jest/types" "^29.6.3"
+    "@jridgewell/trace-mapping" "^0.3.18"
+    "@types/node" "*"
     chalk "^4.0.0"
     collect-v8-coverage "^1.0.0"
     exit "^0.1.2"
-    glob "^7.1.2"
-    graceful-fs "^4.2.4"
+    glob "^7.1.3"
+    graceful-fs "^4.2.9"
     istanbul-lib-coverage "^3.0.0"
-    istanbul-lib-instrument "^4.0.3"
+    istanbul-lib-instrument "^6.0.0"
     istanbul-lib-report "^3.0.0"
     istanbul-lib-source-maps "^4.0.0"
-    istanbul-reports "^3.0.2"
-    jest-haste-map "^27.0.6"
-    jest-resolve "^27.0.6"
-    jest-util "^27.0.6"
-    jest-worker "^27.0.6"
+    istanbul-reports "^3.1.3"
+    jest-message-util "^29.7.0"
+    jest-util "^29.7.0"
+    jest-worker "^29.7.0"
     slash "^3.0.0"
-    source-map "^0.6.0"
     string-length "^4.0.1"
-    terminal-link "^2.0.0"
-    v8-to-istanbul "^8.0.0"
+    strip-ansi "^6.0.0"
+    v8-to-istanbul "^9.0.1"
 
-"@jest/source-map@^27.0.6":
-  version "27.0.6"
-  resolved "https://registry.yarnpkg.com/@jest/source-map/-/source-map-27.0.6.tgz#be9e9b93565d49b0548b86e232092491fb60551f"
-  integrity sha512-Fek4mi5KQrqmlY07T23JRi0e7Z9bXTOOD86V/uS0EIW4PClvPDqZOyFlLpNJheS6QI0FNX1CgmPjtJ4EA/2M+g==
+"@jest/schemas@^29.6.3":
+  version "29.6.3"
+  resolved "https://registry.yarnpkg.com/@jest/schemas/-/schemas-29.6.3.tgz#430b5ce8a4e0044a7e3819663305a7b3091c8e03"
+  integrity sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==
   dependencies:
+    "@sinclair/typebox" "^0.27.8"
+
+"@jest/source-map@^29.6.3":
+  version "29.6.3"
+  resolved "https://registry.yarnpkg.com/@jest/source-map/-/source-map-29.6.3.tgz#d90ba772095cf37a34a5eb9413f1b562a08554c4"
+  integrity sha512-MHjT95QuipcPrpLM+8JMSzFx6eHp5Bm+4XeFDJlwsvVBjmKNiIAvasGK2fxz2WbGRlnvqehFbh07MMa7n3YJnw==
+  dependencies:
+    "@jridgewell/trace-mapping" "^0.3.18"
     callsites "^3.0.0"
-    graceful-fs "^4.2.4"
-    source-map "^0.6.0"
+    graceful-fs "^4.2.9"
 
-"@jest/test-result@^27.0.6":
-  version "27.0.6"
-  resolved "https://registry.yarnpkg.com/@jest/test-result/-/test-result-27.0.6.tgz#3fa42015a14e4fdede6acd042ce98c7f36627051"
-  integrity sha512-ja/pBOMTufjX4JLEauLxE3LQBPaI2YjGFtXexRAjt1I/MbfNlMx0sytSX3tn5hSLzQsR3Qy2rd0hc1BWojtj9w==
+"@jest/test-result@^29.7.0":
+  version "29.7.0"
+  resolved "https://registry.yarnpkg.com/@jest/test-result/-/test-result-29.7.0.tgz#8db9a80aa1a097bb2262572686734baed9b1657c"
+  integrity sha512-Fdx+tv6x1zlkJPcWXmMDAG2HBnaR9XPSd5aDWQVsfrZmLVT3lU1cwyxLgRmXR9yrq4NBoEm9BMsfgFzTQAbJYA==
   dependencies:
-    "@jest/console" "^27.0.6"
-    "@jest/types" "^27.0.6"
+    "@jest/console" "^29.7.0"
+    "@jest/types" "^29.6.3"
     "@types/istanbul-lib-coverage" "^2.0.0"
     collect-v8-coverage "^1.0.0"
 
-"@jest/test-sequencer@^27.0.6":
-  version "27.0.6"
-  resolved "https://registry.yarnpkg.com/@jest/test-sequencer/-/test-sequencer-27.0.6.tgz#80a913ed7a1130545b1cd777ff2735dd3af5d34b"
-  integrity sha512-bISzNIApazYOlTHDum9PwW22NOyDa6VI31n6JucpjTVM0jD6JDgqEZ9+yn575nDdPF0+4csYDxNNW13NvFQGZA==
+"@jest/test-sequencer@^29.7.0":
+  version "29.7.0"
+  resolved "https://registry.yarnpkg.com/@jest/test-sequencer/-/test-sequencer-29.7.0.tgz#6cef977ce1d39834a3aea887a1726628a6f072ce"
+  integrity sha512-GQwJ5WZVrKnOJuiYiAF52UNUJXgTZx1NHjFSEB0qEMmSZKAkdMoIzw/Cj6x6NF4AvV23AUqDpFzQkN/eYCYTxw==
   dependencies:
-    "@jest/test-result" "^27.0.6"
-    graceful-fs "^4.2.4"
-    jest-haste-map "^27.0.6"
-    jest-runtime "^27.0.6"
-
-"@jest/transform@^27.0.6":
-  version "27.0.6"
-  resolved "https://registry.yarnpkg.com/@jest/transform/-/transform-27.0.6.tgz#189ad7107413208f7600f4719f81dd2f7278cc95"
-  integrity sha512-rj5Dw+mtIcntAUnMlW/Vju5mr73u8yg+irnHwzgtgoeI6cCPOvUwQ0D1uQtc/APmWgvRweEb1g05pkUpxH3iCA==
-  dependencies:
-    "@babel/core" "^7.1.0"
-    "@jest/types" "^27.0.6"
-    babel-plugin-istanbul "^6.0.0"
-    chalk "^4.0.0"
-    convert-source-map "^1.4.0"
-    fast-json-stable-stringify "^2.0.0"
-    graceful-fs "^4.2.4"
-    jest-haste-map "^27.0.6"
-    jest-regex-util "^27.0.6"
-    jest-util "^27.0.6"
-    micromatch "^4.0.4"
-    pirates "^4.0.1"
+    "@jest/test-result" "^29.7.0"
+    graceful-fs "^4.2.9"
+    jest-haste-map "^29.7.0"
     slash "^3.0.0"
-    source-map "^0.6.1"
-    write-file-atomic "^3.0.0"
+
+"@jest/transform@^29.7.0":
+  version "29.7.0"
+  resolved "https://registry.yarnpkg.com/@jest/transform/-/transform-29.7.0.tgz#df2dd9c346c7d7768b8a06639994640c642e284c"
+  integrity sha512-ok/BTPFzFKVMwO5eOHRrvnBVHdRy9IrsrW1GpMaQ9MCnilNLXQKmAX8s1YXDFaai9xJpac2ySzV0YeRRECr2Vw==
+  dependencies:
+    "@babel/core" "^7.11.6"
+    "@jest/types" "^29.6.3"
+    "@jridgewell/trace-mapping" "^0.3.18"
+    babel-plugin-istanbul "^6.1.1"
+    chalk "^4.0.0"
+    convert-source-map "^2.0.0"
+    fast-json-stable-stringify "^2.1.0"
+    graceful-fs "^4.2.9"
+    jest-haste-map "^29.7.0"
+    jest-regex-util "^29.6.3"
+    jest-util "^29.7.0"
+    micromatch "^4.0.4"
+    pirates "^4.0.4"
+    slash "^3.0.0"
+    write-file-atomic "^4.0.2"
 
 "@jest/types@^26.6.2":
   version "26.6.2"
@@ -686,16 +1035,51 @@
     "@types/yargs" "^15.0.0"
     chalk "^4.0.0"
 
-"@jest/types@^27.0.6":
-  version "27.0.6"
-  resolved "https://registry.yarnpkg.com/@jest/types/-/types-27.0.6.tgz#9a992bc517e0c49f035938b8549719c2de40706b"
-  integrity sha512-aSquT1qa9Pik26JK5/3rvnYb4bGtm1VFNesHKmNTwmPIgOrixvhL2ghIvFRNEpzy3gU+rUgjIF/KodbkFAl++g==
+"@jest/types@^29.6.3":
+  version "29.6.3"
+  resolved "https://registry.yarnpkg.com/@jest/types/-/types-29.6.3.tgz#1131f8cf634e7e84c5e77bab12f052af585fba59"
+  integrity sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==
   dependencies:
+    "@jest/schemas" "^29.6.3"
     "@types/istanbul-lib-coverage" "^2.0.0"
     "@types/istanbul-reports" "^3.0.0"
     "@types/node" "*"
-    "@types/yargs" "^16.0.0"
+    "@types/yargs" "^17.0.8"
     chalk "^4.0.0"
+
+"@jridgewell/gen-mapping@^0.3.12", "@jridgewell/gen-mapping@^0.3.5":
+  version "0.3.13"
+  resolved "https://registry.yarnpkg.com/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz#6342a19f44347518c93e43b1ac69deb3c4656a1f"
+  integrity sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==
+  dependencies:
+    "@jridgewell/sourcemap-codec" "^1.5.0"
+    "@jridgewell/trace-mapping" "^0.3.24"
+
+"@jridgewell/remapping@^2.3.5":
+  version "2.3.5"
+  resolved "https://registry.yarnpkg.com/@jridgewell/remapping/-/remapping-2.3.5.tgz#375c476d1972947851ba1e15ae8f123047445aa1"
+  integrity sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==
+  dependencies:
+    "@jridgewell/gen-mapping" "^0.3.5"
+    "@jridgewell/trace-mapping" "^0.3.24"
+
+"@jridgewell/resolve-uri@^3.1.0":
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz#7a0ee601f60f99a20c7c7c5ff0c80388c1189bd6"
+  integrity sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==
+
+"@jridgewell/sourcemap-codec@^1.4.14", "@jridgewell/sourcemap-codec@^1.5.0":
+  version "1.5.5"
+  resolved "https://registry.yarnpkg.com/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz#6912b00d2c631c0d15ce1a7ab57cd657f2a8f8ba"
+  integrity sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==
+
+"@jridgewell/trace-mapping@^0.3.12", "@jridgewell/trace-mapping@^0.3.18", "@jridgewell/trace-mapping@^0.3.24", "@jridgewell/trace-mapping@^0.3.28":
+  version "0.3.31"
+  resolved "https://registry.yarnpkg.com/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz#db15d6781c931f3a251a3dac39501c98a6082fd0"
+  integrity sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==
+  dependencies:
+    "@jridgewell/resolve-uri" "^3.1.0"
+    "@jridgewell/sourcemap-codec" "^1.4.14"
 
 "@manypkg/find-root@^1.1.0":
   version "1.1.0"
@@ -718,6 +1102,11 @@
     globby "^11.0.0"
     read-yaml-file "^1.1.0"
 
+"@nodable/entities@^2.1.0":
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/@nodable/entities/-/entities-2.2.0.tgz#a1d45a992b022591b1c2b03a77935c939375b642"
+  integrity sha512-9uGyhaQavEUMC8AIddIjau4NsnsXhou+j5sBAGojCM1oxmQpVKTWR/9JxABD6UAv12vpIms55fPZKFQEhG6uBg==
+
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"
   resolved "https://registry.yarnpkg.com/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz#7619c2eb21b25483f6d167548b4cfd5a7488c3d5"
@@ -739,26 +1128,101 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
-"@sinonjs/commons@^1.7.0":
-  version "1.8.3"
-  resolved "https://registry.yarnpkg.com/@sinonjs/commons/-/commons-1.8.3.tgz#3802ddd21a50a949b6721ddd72da36e67e7f1b2d"
-  integrity sha512-xkNcLAn/wZaX14RPlwizcKicDk9G3F8m2nU3L7Ukm5zBgTwiT0wsoFAHx9Jq56fJA1z/7uKGtCRu16sOUCLIHQ==
+"@sinclair/typebox@^0.27.8":
+  version "0.27.10"
+  resolved "https://registry.yarnpkg.com/@sinclair/typebox/-/typebox-0.27.10.tgz#beefe675f1853f73676aecc915b2bd2ac98c4fc6"
+  integrity sha512-MTBk/3jGLNB2tVxv6uLlFh1iu64iYOQ2PbdOSK3NW8JZsmlaOh2q6sdtKowBhfw8QFLmYNzTW4/oK4uATIi6ZA==
+
+"@sinonjs/commons@^3.0.0":
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/@sinonjs/commons/-/commons-3.0.1.tgz#1029357e44ca901a615585f6d27738dbc89084cd"
+  integrity sha512-K3mCHKQ9sVh8o1C9cxkwxaOmXoAMlDxC1mYyHrjqOWEcBjYr76t96zL2zlj5dUGZ3HSw240X1qgH3Mjf1yJWpQ==
   dependencies:
     type-detect "4.0.8"
 
-"@sinonjs/fake-timers@^7.0.2":
-  version "7.1.2"
-  resolved "https://registry.yarnpkg.com/@sinonjs/fake-timers/-/fake-timers-7.1.2.tgz#2524eae70c4910edccf99b2f4e6efc5894aff7b5"
-  integrity sha512-iQADsW4LBMISqZ6Ci1dupJL9pprqwcVFTcOsEmQOEhW+KLCVn/Y4Jrvg2k19fIHCp+iFprriYPTdRcQR8NbUPg==
+"@sinonjs/fake-timers@^10.0.2":
+  version "10.3.0"
+  resolved "https://registry.yarnpkg.com/@sinonjs/fake-timers/-/fake-timers-10.3.0.tgz#55fdff1ecab9f354019129daf4df0dd4d923ea66"
+  integrity sha512-V4BG07kuYSUkTCSBHG8G8TNhM+F19jXFWnQtzj+we8DrkpSBCee9Z3Ms8yiGer/dlmhe35/Xdgyo3/0rQKg7YA==
   dependencies:
-    "@sinonjs/commons" "^1.7.0"
+    "@sinonjs/commons" "^3.0.0"
 
-"@tootallnate/once@1":
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/@tootallnate/once/-/once-1.1.2.tgz#ccb91445360179a04e7fe6aff78c00ffc1eeaf82"
-  integrity sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==
+"@smithy/core@^3.24.6", "@smithy/core@^3.24.7":
+  version "3.24.7"
+  resolved "https://registry.yarnpkg.com/@smithy/core/-/core-3.24.7.tgz#040621b1150844abf763fc77691232ea0719a006"
+  integrity sha512-KoUi4M1f3BG6kzN1FnCwL7oyFptTbyBJKjR6yhSib+JHRdUmM1o+VwsFtJ66NZCkCzVfJMWRHJNo0R0jznp0Pg==
+  dependencies:
+    "@aws-crypto/crc32" "5.2.0"
+    "@smithy/types" "^4.14.4"
+    tslib "^2.6.2"
 
-"@types/babel__core@^7.0.0", "@types/babel__core@^7.1.14":
+"@smithy/credential-provider-imds@^4.3.7":
+  version "4.3.9"
+  resolved "https://registry.yarnpkg.com/@smithy/credential-provider-imds/-/credential-provider-imds-4.3.9.tgz#3bb51eea08fb40c519df3c4d3b7c5d24dde0094d"
+  integrity sha512-ZlfJ/4Fa3jYb+3eaohPfG9utX9HmdhFNcFtpoGAhUhdynAOmGXtmigbi7eEiONKM+ykHw8RwKuDEb85Lx7t7fA==
+  dependencies:
+    "@smithy/core" "^3.24.7"
+    "@smithy/types" "^4.14.4"
+    tslib "^2.6.2"
+
+"@smithy/fetch-http-handler@^5.4.6":
+  version "5.4.7"
+  resolved "https://registry.yarnpkg.com/@smithy/fetch-http-handler/-/fetch-http-handler-5.4.7.tgz#fe82b38c6201aa4a413062020cf47c35bd4d44c0"
+  integrity sha512-NslaM2ir0N2hisDmzXLstPaVINZheh8SokyOC++kzFPloZucL2R7Y7bS57mSzx/1Fc/fqmn7twjkeezTTrV0EA==
+  dependencies:
+    "@smithy/core" "^3.24.7"
+    "@smithy/types" "^4.14.4"
+    tslib "^2.6.2"
+
+"@smithy/is-array-buffer@^2.2.0":
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz#f84f0d9f9a36601a9ca9381688bd1b726fd39111"
+  integrity sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==
+  dependencies:
+    tslib "^2.6.2"
+
+"@smithy/node-http-handler@^4.7.6":
+  version "4.7.8"
+  resolved "https://registry.yarnpkg.com/@smithy/node-http-handler/-/node-http-handler-4.7.8.tgz#c6a42bc967cc1d9961b1be54d4f3fc5f38f8f4bc"
+  integrity sha512-f+DbsWUwSbtMu1a/j8Y93KiU1SRg9nyzfjereqn1BJ33QOTUXxdlYvVXMhAYl1vuR1Kmna5aIJe09KSIfyFNYw==
+  dependencies:
+    "@smithy/core" "^3.24.7"
+    "@smithy/types" "^4.14.4"
+    tslib "^2.6.2"
+
+"@smithy/signature-v4@^5.4.6":
+  version "5.4.7"
+  resolved "https://registry.yarnpkg.com/@smithy/signature-v4/-/signature-v4-5.4.7.tgz#a56fc486928bb54d822f1f18f81a1e00328e78ce"
+  integrity sha512-LwQZazFayImv+IOm0S0enoLeUJwmAlhGC5O6YCcLWezyu08dF46GOxPOq35OpBIHkgd7OvNvBStIFwVNyrvoBw==
+  dependencies:
+    "@smithy/core" "^3.24.7"
+    "@smithy/types" "^4.14.4"
+    tslib "^2.6.2"
+
+"@smithy/types@^4.14.3", "@smithy/types@^4.14.4":
+  version "4.14.4"
+  resolved "https://registry.yarnpkg.com/@smithy/types/-/types-4.14.4.tgz#0c83b7e011d30730ec43fa13290e61a7ca234ccc"
+  integrity sha512-B2S9+UGm1+/pHkcx3ZoLVX1a+pmSk8rqxRR+ZsNqZaJ5q9FWX9AFGQVM4qG5+OBeQUZVy99HY8HqW8gK/wgXzQ==
+  dependencies:
+    tslib "^2.6.2"
+
+"@smithy/util-buffer-from@^2.2.0":
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz#6fc88585165ec73f8681d426d96de5d402021e4b"
+  integrity sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==
+  dependencies:
+    "@smithy/is-array-buffer" "^2.2.0"
+    tslib "^2.6.2"
+
+"@smithy/util-utf8@^2.0.0":
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/@smithy/util-utf8/-/util-utf8-2.3.0.tgz#dd96d7640363259924a214313c3cf16e7dd329c5"
+  integrity sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==
+  dependencies:
+    "@smithy/util-buffer-from" "^2.2.0"
+    tslib "^2.6.2"
+
+"@types/babel__core@^7.1.14":
   version "7.1.15"
   resolved "https://registry.yarnpkg.com/@types/babel__core/-/babel__core-7.1.15.tgz#2ccfb1ad55a02c83f8e0ad327cbc332f55eb1024"
   integrity sha512-bxlMKPDbY8x5h6HBwVzEOk2C8fb6SLfYQ5Jw3uBYuYF1lfWk/kbLd81la82vrIkBb0l+JdmrZaDikPrNxpS/Ew==
@@ -798,6 +1262,13 @@
   dependencies:
     "@types/node" "*"
 
+"@types/graceful-fs@^4.1.3":
+  version "4.1.9"
+  resolved "https://registry.yarnpkg.com/@types/graceful-fs/-/graceful-fs-4.1.9.tgz#2a06bc0f68a20ab37b3e36aa238be6abdf49e8b4"
+  integrity sha512-olP3sd1qOEe5dXTSaFvQG+02VdRXcdytWLAZsAq1PecU8uqQAhkrnbli7DagjtXKW/Bl7YJbUsa8MPcuc8LHEQ==
+  dependencies:
+    "@types/node" "*"
+
 "@types/istanbul-lib-coverage@*", "@types/istanbul-lib-coverage@^2.0.0", "@types/istanbul-lib-coverage@^2.0.1":
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.3.tgz#4ba8ddb720221f432e443bd5f9117fd22cfd4762"
@@ -817,21 +1288,13 @@
   dependencies:
     "@types/istanbul-lib-report" "*"
 
-"@types/jest@^26.0.24":
-  version "26.0.24"
-  resolved "https://registry.yarnpkg.com/@types/jest/-/jest-26.0.24.tgz#943d11976b16739185913a1936e0de0c4a7d595a"
-  integrity sha512-E/X5Vib8BWqZNRlDxj9vYXhsDwPYbPINqKF9BsnSoon4RQ0D9moEuLD8txgyypFLH7J4+Lho9Nr/c8H0Fi+17w==
+"@types/jest@^29.5.0":
+  version "29.5.14"
+  resolved "https://registry.yarnpkg.com/@types/jest/-/jest-29.5.14.tgz#2b910912fa1d6856cadcd0c1f95af7df1d6049e5"
+  integrity sha512-ZN+4sdnLUbo8EVvVc2ao0GFW6oVrQRPn4K2lglySj7APvSrgzxHiNNK99us4WDMi57xxA2yggblIAMNhXOotLQ==
   dependencies:
-    jest-diff "^26.0.0"
-    pretty-format "^26.0.0"
-
-"@types/jest@^27.4.0":
-  version "27.5.0"
-  resolved "https://registry.yarnpkg.com/@types/jest/-/jest-27.5.0.tgz#e04ed1824ca6b1dd0438997ba60f99a7405d4c7b"
-  integrity sha512-9RBFx7r4k+msyj/arpfaa0WOOEcaAZNmN+j80KFbFCoSqCJGHTz7YMAMGQW9Xmqm5w6l5c25vbSjMwlikJi5+g==
-  dependencies:
-    jest-matcher-utils "^27.0.0"
-    pretty-format "^27.0.0"
+    expect "^29.0.0"
+    pretty-format "^29.0.0"
 
 "@types/minimist@^1.2.0":
   version "1.2.2"
@@ -843,6 +1306,13 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-16.3.1.tgz#24691fa2b0c3ec8c0d34bfcfd495edac5593ebb4"
   integrity sha512-N87VuQi7HEeRJkhzovao/JviiqKjDKMVKxKMfUvSKw+MbkbW8R0nA3fi/MQhhlxV2fQ+2ReM+/Nt4efdrJx3zA==
 
+"@types/node@20.11.0":
+  version "20.11.0"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-20.11.0.tgz#8e0b99e70c0c1ade1a86c4a282f7b7ef87c9552f"
+  integrity sha512-o9bjXmDNcF7GbM4CNQpmi+TutCgap/K3w1JyKgxAjqx41zp9qlIAVFi0IhCNsJcXolEqLWhbFbEeL0PvYm4pcQ==
+  dependencies:
+    undici-types "~5.26.4"
+
 "@types/node@^12.7.1":
   version "12.20.16"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-12.20.16.tgz#1acf34f6456208f495dac0434dd540488d17f991"
@@ -853,7 +1323,7 @@
   resolved "https://registry.yarnpkg.com/@types/normalize-package-data/-/normalize-package-data-2.4.1.tgz#d3357479a0fdfdd5907fe67e17e0a85c906e1301"
   integrity sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw==
 
-"@types/prettier@^2.0.0", "@types/prettier@^2.1.5":
+"@types/prettier@^2.0.0":
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/@types/prettier/-/prettier-2.3.2.tgz#fc8c2825e4ed2142473b4a81064e6e081463d1b3"
   integrity sha512-eI5Yrz3Qv4KPUa/nSIAi0h+qX0XyewOliug5F2QAtuRg6Kjg6jfmxe1GIwoIRhZspD1A0RP8ANrPwvEXXtRFog==
@@ -885,47 +1355,12 @@
   dependencies:
     "@types/yargs-parser" "*"
 
-"@types/yargs@^16.0.0":
-  version "16.0.4"
-  resolved "https://registry.yarnpkg.com/@types/yargs/-/yargs-16.0.4.tgz#26aad98dd2c2a38e421086ea9ad42b9e51642977"
-  integrity sha512-T8Yc9wt/5LbJyCaLiHPReJa0kApcIgJ7Bn735GjItUfh08Z1pJvu8QZqb9s+mMvKV6WUQRV7K2R46YbjMXTTJw==
+"@types/yargs@^17.0.8":
+  version "17.0.35"
+  resolved "https://registry.yarnpkg.com/@types/yargs/-/yargs-17.0.35.tgz#07013e46aa4d7d7d50a49e15604c1c5340d4eb24"
+  integrity sha512-qUHkeCyQFxMXg79wQfTtfndEC+N9ZZg76HJftDJp+qH2tV7Gj4OJi7l+PiWwJ+pWtW8GwSmqsDj/oymhrTWXjg==
   dependencies:
     "@types/yargs-parser" "*"
-
-abab@^2.0.3, abab@^2.0.5:
-  version "2.0.5"
-  resolved "https://registry.yarnpkg.com/abab/-/abab-2.0.5.tgz#c0b678fb32d60fc1219c784d6a826fe385aeb79a"
-  integrity sha512-9IK9EadsbHo6jLWIpxpR6pL0sazTXV6+SQv25ZB+F7Bj9mJNaOc4nCRabwd5M/JwmUa8idz6Eci6eKfJryPs6Q==
-
-acorn-globals@^6.0.0:
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/acorn-globals/-/acorn-globals-6.0.0.tgz#46cdd39f0f8ff08a876619b55f5ac8a6dc770b45"
-  integrity sha512-ZQl7LOWaF5ePqqcX4hLuv/bLXYQNfNWw2c0/yX/TsPRKamzHcTGQnlCjHT3TsmkOUVEPS3crCxiPfdzE/Trlhg==
-  dependencies:
-    acorn "^7.1.1"
-    acorn-walk "^7.1.1"
-
-acorn-walk@^7.1.1:
-  version "7.2.0"
-  resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-7.2.0.tgz#0de889a601203909b0fbe07b8938dc21d2e967bc"
-  integrity sha512-OPdCF6GsMIP+Az+aWfAAOEt2/+iVDKE7oy6lJ098aoe59oAmK76qV6Gw60SbZ8jHuG2wH058GF4pLFbYamYrVA==
-
-acorn@^7.1.1:
-  version "7.4.1"
-  resolved "https://registry.yarnpkg.com/acorn/-/acorn-7.4.1.tgz#feaed255973d2e77555b83dbc08851a6c63520fa"
-  integrity sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==
-
-acorn@^8.2.4:
-  version "8.4.1"
-  resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.4.1.tgz#56c36251fc7cabc7096adc18f05afe814321a28c"
-  integrity sha512-asabaBSkEKosYKMITunzX177CXxQ4Q8BSSzMTKD+FefUhipQC70gfW5SiUDhYQ3vk8G+81HqQk7Fv9OXwwn9KA==
-
-agent-base@6:
-  version "6.0.2"
-  resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-6.0.2.tgz#49fff58577cfee3f37176feab4c22e00f86d7f77"
-  integrity sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==
-  dependencies:
-    debug "4"
 
 ansi-align@^2.0.0:
   version "2.0.0"
@@ -996,6 +1431,11 @@ anymatch@^3.0.3:
     normalize-path "^3.0.0"
     picomatch "^2.0.4"
 
+anynum@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/anynum/-/anynum-1.0.0.tgz#afe3f3a78c6621fbdf1e107154fac01eef711cc5"
+  integrity sha512-xjR9/zBVnUOP6ztMIIgShjsxui80nQUQH+5xJnvrYLs+90bF25/KJqaAi8mk+B4RDtX1Nspi6fmp4YTEts8SfA==
+
 argparse@^1.0.7:
   version "1.0.10"
   resolved "https://registry.yarnpkg.com/argparse/-/argparse-1.0.10.tgz#bcd6791ea5ae09725e17e5ad988134cd40b3d911"
@@ -1038,64 +1478,43 @@ assign-symbols@^1.0.0:
   resolved "https://registry.yarnpkg.com/assign-symbols/-/assign-symbols-1.0.0.tgz#59667f41fadd4f20ccbc2bb96b8d4f7f78ec0367"
   integrity sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=
 
-asynckit@^0.4.0:
-  version "0.4.0"
-  resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
-  integrity sha1-x57Zf380y48robyXkLzDZkdLS3k=
-
 atob@^2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/atob/-/atob-2.1.2.tgz#6d9517eb9e030d2436666651e86bd9f6f13533c9"
   integrity sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==
 
-aws-sdk@^2.691.0:
-  version "2.943.0"
-  resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.943.0.tgz#6bda506cc33f5e7ec14e58ca4847e9abbab05c13"
-  integrity sha512-1/WDupJrIB0SJEzIOf+UpqmG0AP5AXoDXhbW7CEujHerOd+/b5A1ubeHKGQJvBN4tAktgsvGpDiBRfB9MpJU5g==
+babel-jest@^29.7.0:
+  version "29.7.0"
+  resolved "https://registry.yarnpkg.com/babel-jest/-/babel-jest-29.7.0.tgz#f4369919225b684c56085998ac63dbd05be020d5"
+  integrity sha512-BrvGY3xZSwEcCzKvKsCi2GgHqDqsYkOP4/by5xCgIwGXQxIEh+8ew3gmrE1y7XRR6LHZIj6yLYnUi/mm2KXKBg==
   dependencies:
-    buffer "4.9.2"
-    events "1.1.1"
-    ieee754 "1.1.13"
-    jmespath "0.15.0"
-    querystring "0.2.0"
-    sax "1.2.1"
-    url "0.10.3"
-    uuid "3.3.2"
-    xml2js "0.4.19"
-
-babel-jest@^27.0.6:
-  version "27.0.6"
-  resolved "https://registry.yarnpkg.com/babel-jest/-/babel-jest-27.0.6.tgz#e99c6e0577da2655118e3608b68761a5a69bd0d8"
-  integrity sha512-iTJyYLNc4wRofASmofpOc5NK9QunwMk+TLFgGXsTFS8uEqmd8wdI7sga0FPe2oVH3b5Agt/EAK1QjPEuKL8VfA==
-  dependencies:
-    "@jest/transform" "^27.0.6"
-    "@jest/types" "^27.0.6"
+    "@jest/transform" "^29.7.0"
     "@types/babel__core" "^7.1.14"
-    babel-plugin-istanbul "^6.0.0"
-    babel-preset-jest "^27.0.6"
+    babel-plugin-istanbul "^6.1.1"
+    babel-preset-jest "^29.6.3"
     chalk "^4.0.0"
-    graceful-fs "^4.2.4"
+    graceful-fs "^4.2.9"
     slash "^3.0.0"
 
-babel-plugin-istanbul@^6.0.0:
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/babel-plugin-istanbul/-/babel-plugin-istanbul-6.0.0.tgz#e159ccdc9af95e0b570c75b4573b7c34d671d765"
-  integrity sha512-AF55rZXpe7trmEylbaE1Gv54wn6rwU03aptvRoVIGP8YykoSxqdVLV1TfwflBCE/QtHmqtP8SWlTENqbK8GCSQ==
+babel-plugin-istanbul@^6.1.1:
+  version "6.1.1"
+  resolved "https://registry.yarnpkg.com/babel-plugin-istanbul/-/babel-plugin-istanbul-6.1.1.tgz#fa88ec59232fd9b4e36dbbc540a8ec9a9b47da73"
+  integrity sha512-Y1IQok9821cC9onCx5otgFfRm7Lm+I+wwxOx738M/WLPZ9Q42m4IG5W0FNX8WLL2gYMZo3JkuXIH2DOpWM+qwA==
   dependencies:
     "@babel/helper-plugin-utils" "^7.0.0"
     "@istanbuljs/load-nyc-config" "^1.0.0"
     "@istanbuljs/schema" "^0.1.2"
-    istanbul-lib-instrument "^4.0.0"
+    istanbul-lib-instrument "^5.0.4"
     test-exclude "^6.0.0"
 
-babel-plugin-jest-hoist@^27.0.6:
-  version "27.0.6"
-  resolved "https://registry.yarnpkg.com/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-27.0.6.tgz#f7c6b3d764af21cb4a2a1ab6870117dbde15b456"
-  integrity sha512-CewFeM9Vv2gM7Yr9n5eyyLVPRSiBnk6lKZRjgwYnGKSl9M14TMn2vkN02wTF04OGuSDLEzlWiMzvjXuW9mB6Gw==
+babel-plugin-jest-hoist@^29.6.3:
+  version "29.6.3"
+  resolved "https://registry.yarnpkg.com/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-29.6.3.tgz#aadbe943464182a8922c3c927c3067ff40d24626"
+  integrity sha512-ESAc/RJvGTFEzRwOTT4+lNDk/GNHMkKbNzsvT0qKRfDyyYTskxB5rnU2njIDYVxXCBHHEI1c0YwHob3WaYujOg==
   dependencies:
     "@babel/template" "^7.3.3"
     "@babel/types" "^7.3.3"
-    "@types/babel__core" "^7.0.0"
+    "@types/babel__core" "^7.1.14"
     "@types/babel__traverse" "^7.0.6"
 
 babel-preset-current-node-syntax@^1.0.0:
@@ -1116,23 +1535,18 @@ babel-preset-current-node-syntax@^1.0.0:
     "@babel/plugin-syntax-optional-chaining" "^7.8.3"
     "@babel/plugin-syntax-top-level-await" "^7.8.3"
 
-babel-preset-jest@^27.0.6:
-  version "27.0.6"
-  resolved "https://registry.yarnpkg.com/babel-preset-jest/-/babel-preset-jest-27.0.6.tgz#909ef08e9f24a4679768be2f60a3df0856843f9d"
-  integrity sha512-WObA0/Biw2LrVVwZkF/2GqbOdzhKD6Fkdwhoy9ASIrOWr/zodcSpQh72JOkEn6NWyjmnPDjNSqaGN4KnpKzhXw==
+babel-preset-jest@^29.6.3:
+  version "29.6.3"
+  resolved "https://registry.yarnpkg.com/babel-preset-jest/-/babel-preset-jest-29.6.3.tgz#fa05fa510e7d493896d7b0dd2033601c840f171c"
+  integrity sha512-0B3bhxR6snWXJZtR/RliHTDPRgn1sNHOR0yVtq/IiQFyuOVjFS+wuio/R4gSNkyYmKmJB4wGZv2NZanmKmTnNA==
   dependencies:
-    babel-plugin-jest-hoist "^27.0.6"
+    babel-plugin-jest-hoist "^29.6.3"
     babel-preset-current-node-syntax "^1.0.0"
 
 balanced-match@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.2.tgz#e83e3a7e3f300b34cb9d87f615fa0cbf357690ee"
   integrity sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==
-
-base64-js@^1.0.2:
-  version "1.5.1"
-  resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.5.1.tgz#1b1b440160a5bf7ad40b650f095963481903930a"
-  integrity sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==
 
 base@^0.11.1:
   version "0.11.2"
@@ -1147,12 +1561,22 @@ base@^0.11.1:
     mixin-deep "^1.2.0"
     pascalcase "^0.1.1"
 
+baseline-browser-mapping@^2.10.12:
+  version "2.10.37"
+  resolved "https://registry.yarnpkg.com/baseline-browser-mapping/-/baseline-browser-mapping-2.10.37.tgz#3e636475b6b293244e2b23e2c71a2ab9d9e6ba7d"
+  integrity sha512-girxaJ7WZssDOFhzCGZTDKoTa1gk6A1TbflaYTpykLJ4UU9Fz9kx1aREM8JCuoVHbL8X8T/mJg7w2oYSq72Oig==
+
 better-path-resolve@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/better-path-resolve/-/better-path-resolve-1.0.0.tgz#13a35a1104cdd48a7b74bf8758f96a1ee613f99d"
   integrity sha512-pbnl5XzGBdrFU/wT4jqmJVPn2B6UHPBOhzMQkY/SPUPB6QtUXtmBHBIwCbXJol93mOpGMnQyP/+BB19q04xj7g==
   dependencies:
     is-windows "^1.0.0"
+
+bowser@^2.11.0:
+  version "2.14.1"
+  resolved "https://registry.yarnpkg.com/bowser/-/bowser-2.14.1.tgz#4ea39bf31e305184522d7ad7bfd91389e4f0cb79"
+  integrity sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==
 
 boxen@^1.3.0:
   version "1.3.0"
@@ -1205,23 +1629,18 @@ breakword@^1.0.5:
   dependencies:
     wcwidth "^1.0.1"
 
-browser-process-hrtime@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/browser-process-hrtime/-/browser-process-hrtime-1.0.0.tgz#3c9b4b7d782c8121e56f10106d84c0d0ffc94626"
-  integrity sha512-9o5UecI3GhkpM6DrXr69PblIuWxPKk9Y0jHBRhdocZ2y7YECBFCsHm79Pr3OyR2AvjhDkabFJaDJMYRazHgsow==
-
-browserslist@^4.16.6:
-  version "4.16.6"
-  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.16.6.tgz#d7901277a5a88e554ed305b183ec9b0c08f66fa2"
-  integrity sha512-Wspk/PqO+4W9qp5iUTJsa1B/QrYn1keNCcEP5OvP7WBwT4KaDly0uONYmC6Xa3Z5IqnUgS0KcgLYu1l74x0ZXQ==
+browserslist@^4.24.0:
+  version "4.28.2"
+  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.28.2.tgz#f50b65362ef48974ca9f50b3680566d786b811d2"
+  integrity sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==
   dependencies:
-    caniuse-lite "^1.0.30001219"
-    colorette "^1.2.2"
-    electron-to-chromium "^1.3.723"
-    escalade "^3.1.1"
-    node-releases "^1.1.71"
+    baseline-browser-mapping "^2.10.12"
+    caniuse-lite "^1.0.30001782"
+    electron-to-chromium "^1.5.328"
+    node-releases "^2.0.36"
+    update-browserslist-db "^1.2.3"
 
-bs-logger@0.x:
+bs-logger@^0.2.6:
   version "0.2.6"
   resolved "https://registry.yarnpkg.com/bs-logger/-/bs-logger-0.2.6.tgz#eb7d365307a72cf974cc6cda76b68354ad336bd8"
   integrity sha512-pd8DCoxmbgc7hyPKOvxtqNcjYoOsABPQdcCUjGp3d42VR2CX1ORhk2A87oqqu5R1kk+76nsxZupkmyd+MVtCog==
@@ -1235,19 +1654,10 @@ bser@2.1.1:
   dependencies:
     node-int64 "^0.4.0"
 
-buffer-from@1.x, buffer-from@^1.0.0:
+buffer-from@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.1.tgz#32713bc028f75c02fdb710d7c7bcec1f2c6070ef"
   integrity sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==
-
-buffer@4.9.2:
-  version "4.9.2"
-  resolved "https://registry.yarnpkg.com/buffer/-/buffer-4.9.2.tgz#230ead344002988644841ab0244af8c44bbe3ef8"
-  integrity sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==
-  dependencies:
-    base64-js "^1.0.2"
-    ieee754 "^1.1.4"
-    isarray "^1.0.0"
 
 cache-base@^1.0.1:
   version "1.0.1"
@@ -1293,10 +1703,10 @@ camelcase@^6.2.0:
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-6.2.0.tgz#924af881c9d525ac9d87f40d964e5cea982a1809"
   integrity sha512-c7wVvbw3f37nuobQNtgsgG9POC9qMbNuMQmTCqZv23b6MIz0fcYpBiOlv9gEN/hdLdnZTDQhg6e9Dq5M1vKvfg==
 
-caniuse-lite@^1.0.30001219:
-  version "1.0.30001243"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001243.tgz#d9250155c91e872186671c523f3ae50cfc94a3aa"
-  integrity sha512-vNxw9mkTBtkmLFnJRv/2rhs1yufpDfCkBZexG3Y0xdOH2Z/eE/85E4Dl5j1YUN34nZVsSp6vVRFQRrez9wJMRA==
+caniuse-lite@^1.0.30001782:
+  version "1.0.30001799"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001799.tgz#5c909138c27f1a61219d3e092071c1cc7d32dc55"
+  integrity sha512-hG1bReV+OUU+MOqK4t/ZWI0tZOyz3rqS9XuhOUz1cIcbwBKjOyJEJuw9ER5JuNyqxNk8u/JUVbGibBOL1yrjFw==
 
 capture-exit@^2.0.0:
   version "2.0.0"
@@ -1345,10 +1755,10 @@ ci-info@^2.0.0:
   resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-2.0.0.tgz#67a9e964be31a51e15e5010d58e6f12834002f46"
   integrity sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==
 
-ci-info@^3.1.1:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-3.2.0.tgz#2876cb948a498797b5236f0095bc057d0dca38b6"
-  integrity sha512-dVqRX7fLUm8J6FgHJ418XuIgDLZDkYcDFTeL6TA2gt5WlIZUQrrH6EZrNClwT/H0FateUsZkGIOPRrLbP+PR9A==
+ci-info@^3.2.0:
+  version "3.9.0"
+  resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-3.9.0.tgz#4279a62028a7b1f262f3473fc9605f5e218c59b4"
+  integrity sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==
 
 cjs-module-lexer@^1.0.0:
   version "1.2.1"
@@ -1379,13 +1789,13 @@ cliui@^6.0.0:
     strip-ansi "^6.0.0"
     wrap-ansi "^6.2.0"
 
-cliui@^7.0.2:
-  version "7.0.4"
-  resolved "https://registry.yarnpkg.com/cliui/-/cliui-7.0.4.tgz#a0265ee655476fc807aea9df3df8df7783808b4f"
-  integrity sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==
+cliui@^8.0.1:
+  version "8.0.1"
+  resolved "https://registry.yarnpkg.com/cliui/-/cliui-8.0.1.tgz#0c04b075db02cbfe60dc8e6cf2f5486b1a3608aa"
+  integrity sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==
   dependencies:
     string-width "^4.2.0"
-    strip-ansi "^6.0.0"
+    strip-ansi "^6.0.1"
     wrap-ansi "^7.0.0"
 
 clone@^1.0.2:
@@ -1435,18 +1845,6 @@ color-name@~1.1.4:
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2"
   integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
 
-colorette@^1.2.2:
-  version "1.2.2"
-  resolved "https://registry.yarnpkg.com/colorette/-/colorette-1.2.2.tgz#cbcc79d5e99caea2dbf10eb3a26fd8b3e6acfa94"
-  integrity sha512-MKGMzyfeuutC/ZJ1cba9NqcNpfeqMUcYmyF1ZFY6/Cn7CNSAKx6a+s48sqLqyAiZuaP2TcqMhoo+dlwFnVxT9w==
-
-combined-stream@^1.0.8:
-  version "1.0.8"
-  resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.8.tgz#c3d45a8b34fd730631a110a8a2520682b31d5a7f"
-  integrity sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==
-  dependencies:
-    delayed-stream "~1.0.0"
-
 component-emitter@^1.2.1:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/component-emitter/-/component-emitter-1.3.0.tgz#16e4070fba8ae29b679f2215853ee181ab2eabc0"
@@ -1457,17 +1855,28 @@ concat-map@0.0.1:
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
   integrity sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=
 
-convert-source-map@^1.4.0, convert-source-map@^1.6.0, convert-source-map@^1.7.0:
-  version "1.8.0"
-  resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-1.8.0.tgz#f3373c32d21b4d780dd8004514684fb791ca4369"
-  integrity sha512-+OQdjP49zViI/6i7nIJpA8rAl4sV/JdPfU9nZs3VqOwGIgizICvuN2ru6fMd+4llL0tar18UYJXfZ/TWtmhUjA==
-  dependencies:
-    safe-buffer "~5.1.1"
+convert-source-map@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-2.0.0.tgz#4b560f649fc4e918dd0ab75cf4961e8bc882d82a"
+  integrity sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==
 
 copy-descriptor@^0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/copy-descriptor/-/copy-descriptor-0.1.1.tgz#676f6eb3c39997c2ee1ac3a924fd6124748f578d"
   integrity sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=
+
+create-jest@^29.7.0:
+  version "29.7.0"
+  resolved "https://registry.yarnpkg.com/create-jest/-/create-jest-29.7.0.tgz#a355c5b3cb1e1af02ba177fe7afd7feee49a5320"
+  integrity sha512-Adz2bdH0Vq3F53KEMJOoftQFutWCukm6J24wbPWRO4k1kMY7gS7ds/uoJkNuV8wDCtWWnuwGcJwpWcih+zEW1Q==
+  dependencies:
+    "@jest/types" "^29.6.3"
+    chalk "^4.0.0"
+    exit "^0.1.2"
+    graceful-fs "^4.2.9"
+    jest-config "^29.7.0"
+    jest-util "^29.7.0"
+    prompts "^2.0.1"
 
 cross-spawn@^5.0.1, cross-spawn@^5.1.0:
   version "5.1.0"
@@ -1498,23 +1907,6 @@ cross-spawn@^7.0.3:
     shebang-command "^2.0.0"
     which "^2.0.1"
 
-cssom@^0.4.4:
-  version "0.4.4"
-  resolved "https://registry.yarnpkg.com/cssom/-/cssom-0.4.4.tgz#5a66cf93d2d0b661d80bf6a44fb65f5c2e4e0a10"
-  integrity sha512-p3pvU7r1MyyqbTk+WbNJIgJjG2VmTIaB10rI93LzVPrmDJKkzKYMtxxyAvQXR/NS6otuzveI7+7BBq3SjBS2mw==
-
-cssom@~0.3.6:
-  version "0.3.8"
-  resolved "https://registry.yarnpkg.com/cssom/-/cssom-0.3.8.tgz#9f1276f5b2b463f2114d3f2c75250af8c1a36f4a"
-  integrity sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg==
-
-cssstyle@^2.3.0:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/cssstyle/-/cssstyle-2.3.0.tgz#ff665a0ddbdc31864b09647f34163443d90b0852"
-  integrity sha512-AZL67abkUzIuvcHqk7c09cezpGNcxUxU4Ioi/05xHk4DQeTkWmGYftIE6ctU6AEt+Gn4n1lDStOtj7FKycP71A==
-  dependencies:
-    cssom "~0.3.6"
-
 csv-generate@^3.4.0:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/csv-generate/-/csv-generate-3.4.0.tgz#360ed73ef8ec7119515a47c3bd5970ac4b988f00"
@@ -1540,26 +1932,10 @@ csv@^5.3.1:
     csv-stringify "^5.6.2"
     stream-transform "^2.1.0"
 
-data-urls@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/data-urls/-/data-urls-2.0.0.tgz#156485a72963a970f5d5821aaf642bef2bf2db9b"
-  integrity sha512-X5eWTSXO/BJmpdIKCRuKUgSCgAN0OwliVK3yPKbwIWU1Tdw5BRajxlzMidvh+gwko9AfQ9zIj52pzF91Q3YAvQ==
-  dependencies:
-    abab "^2.0.3"
-    whatwg-mimetype "^2.3.0"
-    whatwg-url "^8.0.0"
-
 dataloader@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/dataloader/-/dataloader-2.0.0.tgz#41eaf123db115987e21ca93c005cd7753c55fe6f"
   integrity sha512-YzhyDAwA4TaQIhM5go+vCLmU0UikghC/t9DTQYZR2M/UvZ1MdOhPezSDZcjj9uqQJOMqjLcpWtyW2iNINdlatQ==
-
-debug@4, debug@^4.1.0, debug@^4.1.1:
-  version "4.3.2"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.2.tgz#f0a49c18ac8779e31d4a0c6029dfb76873c7428b"
-  integrity sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==
-  dependencies:
-    ms "2.1.2"
 
 debug@^2.2.0, debug@^2.3.3:
   version "2.6.9"
@@ -1567,6 +1943,20 @@ debug@^2.2.0, debug@^2.3.3:
   integrity sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==
   dependencies:
     ms "2.0.0"
+
+debug@^4.1.0, debug@^4.1.1:
+  version "4.3.2"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.2.tgz#f0a49c18ac8779e31d4a0c6029dfb76873c7428b"
+  integrity sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==
+  dependencies:
+    ms "2.1.2"
+
+debug@^4.3.1:
+  version "4.4.3"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.4.3.tgz#c6ae432d9bd9662582fce08709b038c58e9e3d6a"
+  integrity sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==
+  dependencies:
+    ms "^2.1.3"
 
 decamelize-keys@^1.1.0:
   version "1.1.0"
@@ -1581,25 +1971,15 @@ decamelize@^1.1.0, decamelize@^1.2.0:
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
   integrity sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=
 
-decimal.js@^10.2.1:
-  version "10.3.1"
-  resolved "https://registry.yarnpkg.com/decimal.js/-/decimal.js-10.3.1.tgz#d8c3a444a9c6774ba60ca6ad7261c3a94fd5e783"
-  integrity sha512-V0pfhfr8suzyPGOx3nmq4aHqabehUZn6Ch9kyFpV79TGDTWFmHqUqXdabR7QHqxzrYolF4+tVmJhUG4OURg5dQ==
-
 decode-uri-component@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/decode-uri-component/-/decode-uri-component-0.2.0.tgz#eb3913333458775cb84cd1a1fae062106bb87545"
   integrity sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=
 
-dedent@^0.7.0:
-  version "0.7.0"
-  resolved "https://registry.yarnpkg.com/dedent/-/dedent-0.7.0.tgz#2495ddbaf6eb874abb0e1be9df22d2e5a544326c"
-  integrity sha1-JJXduvbrh0q7Dhvp3yLS5aVEMmw=
-
-deep-is@~0.1.3:
-  version "0.1.3"
-  resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.3.tgz#b369d6fb5dbc13eecf524f91b070feedc357cf34"
-  integrity sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=
+dedent@^1.0.0:
+  version "1.7.2"
+  resolved "https://registry.yarnpkg.com/dedent/-/dedent-1.7.2.tgz#34e2264ab538301e27cf7b07bf2369c19baa8dd9"
+  integrity sha512-WzMx3mW98SN+zn3hgemf4OzdmyNhhhKz5Ay0pUfQiMQ3e1g+xmTJWp/pKdwKVXhdSkAEGIIzqeuWrL3mV/AXbA==
 
 deepmerge@^4.2.2:
   version "4.2.2"
@@ -1635,11 +2015,6 @@ define-property@^2.0.2:
     is-descriptor "^1.0.2"
     isobject "^3.0.1"
 
-delayed-stream@~1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
-  integrity sha1-3zrhmayt+31ECqrgsp4icrJOxhk=
-
 detect-indent@^6.0.0:
   version "6.1.0"
   resolved "https://registry.yarnpkg.com/detect-indent/-/detect-indent-6.1.0.tgz#592485ebbbf6b3b1ab2be175c8393d04ca0d57e6"
@@ -1655,15 +2030,10 @@ diff-sequences@^26.6.2:
   resolved "https://registry.yarnpkg.com/diff-sequences/-/diff-sequences-26.6.2.tgz#48ba99157de1923412eed41db6b6d4aa9ca7c0b1"
   integrity sha512-Mv/TDa3nZ9sbc5soK+OoA74BsS3mL37yixCvUAQkiuA4Wz6YtwP/K47n2rv2ovzHZvoiQeA5FTQOschKkEwB0Q==
 
-diff-sequences@^27.0.6:
-  version "27.0.6"
-  resolved "https://registry.yarnpkg.com/diff-sequences/-/diff-sequences-27.0.6.tgz#3305cb2e55a033924054695cc66019fd7f8e5723"
-  integrity sha512-ag6wfpBFyNXZ0p8pcuIDS//D8H062ZQJ3fzYxjpmeKjnz8W4pekL3AI8VohmyZmsWW2PWaHgjsmqR6L13101VQ==
-
-diff-sequences@^27.5.1:
-  version "27.5.1"
-  resolved "https://registry.yarnpkg.com/diff-sequences/-/diff-sequences-27.5.1.tgz#eaecc0d327fd68c8d9672a1e64ab8dccb2ef5327"
-  integrity sha512-k1gCAXAsNgLwEL+Y8Wvl+M6oEFj5bgazfZULpS5CneoPPXRaCCW7dm+q21Ky2VEE5X+VeRDBVg1Pcvvsr4TtNQ==
+diff-sequences@^29.6.3:
+  version "29.6.3"
+  resolved "https://registry.yarnpkg.com/diff-sequences/-/diff-sequences-29.6.3.tgz#4deaf894d11407c51efc8418012f9e70b84ea921"
+  integrity sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==
 
 dir-glob@^3.0.1:
   version "3.0.1"
@@ -1672,22 +2042,15 @@ dir-glob@^3.0.1:
   dependencies:
     path-type "^4.0.0"
 
-domexception@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/domexception/-/domexception-2.0.1.tgz#fb44aefba793e1574b0af6aed2801d057529f304"
-  integrity sha512-yxJ2mFy/sibVQlu5qHjOkf9J3K6zgmCxgJ94u2EdvDOV09H+32LtRswEcUsmUWN72pVLOEnTSRaIVVzVQgS0dg==
-  dependencies:
-    webidl-conversions "^5.0.0"
+electron-to-chromium@^1.5.328:
+  version "1.5.372"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.5.372.tgz#ae8ac69942a37b231773b8fb01759f73733599e3"
+  integrity sha512-M3yhbAlilnwqC8D21t28UCDGHyitShTmmLRU/H+b74P6Ski16Nb9HONYEaVpMj/pwC7BEo5B95FpjODLCWbtfA==
 
-electron-to-chromium@^1.3.723:
-  version "1.3.772"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.772.tgz#fd1ed39f9f3149f62f581734e4f026e600369479"
-  integrity sha512-X/6VRCXWALzdX+RjCtBU6cyg8WZgoxm9YA02COmDOiNJEZ59WkQggDbWZ4t/giHi/3GS+cvdrP6gbLISANAGYA==
-
-emittery@^0.8.1:
-  version "0.8.1"
-  resolved "https://registry.yarnpkg.com/emittery/-/emittery-0.8.1.tgz#bb23cc86d03b30aa75a7f734819dee2e1ba70860"
-  integrity sha512-uDfvUjVrfGJJhymx/kz6prltenw1u7WrCg1oa94zYY8xxVpLLUu045LAT0dhDZdXG58/EpPL/5kA180fQ/qudg==
+emittery@^0.13.1:
+  version "0.13.1"
+  resolved "https://registry.yarnpkg.com/emittery/-/emittery-0.13.1.tgz#c04b8c3457490e0847ae51fced3af52d338e3dad"
+  integrity sha512-DeWwawk6r5yR9jFgnDKYt4sLS0LmHJJi3ZOnb5/JdbYwj3nW+FxQnHIjhBKz8YLC7oRNPVM9NQ47I3CVx34eqQ==
 
 emoji-regex@^8.0.0:
   version "8.0.0"
@@ -1720,6 +2083,11 @@ escalade@^3.1.1:
   resolved "https://registry.yarnpkg.com/escalade/-/escalade-3.1.1.tgz#d8cfdc7000965c5a0174b4a82eaa5c0552742e40"
   integrity sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==
 
+escalade@^3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/escalade/-/escalade-3.2.0.tgz#011a3f69856ba189dffa7dc8fcce99d2a87903e5"
+  integrity sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==
+
 escape-string-regexp@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
@@ -1730,37 +2098,10 @@ escape-string-regexp@^2.0.0:
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz#a30304e99daa32e23b2fd20f51babd07cffca344"
   integrity sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==
 
-escodegen@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/escodegen/-/escodegen-2.0.0.tgz#5e32b12833e8aa8fa35e1bf0befa89380484c7dd"
-  integrity sha512-mmHKys/C8BFUGI+MAWNcSYoORYLMdPzjrknd2Vc+bUsjN5bXcr8EhrNB+UTqfL1y3I9c4fw2ihgtMPQLBRiQxw==
-  dependencies:
-    esprima "^4.0.1"
-    estraverse "^5.2.0"
-    esutils "^2.0.2"
-    optionator "^0.8.1"
-  optionalDependencies:
-    source-map "~0.6.1"
-
-esprima@^4.0.0, esprima@^4.0.1:
+esprima@^4.0.0:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/esprima/-/esprima-4.0.1.tgz#13b04cdb3e6c5d19df91ab6987a8695619b0aa71"
   integrity sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==
-
-estraverse@^5.2.0:
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-5.2.0.tgz#307df42547e6cc7324d3cf03c155d5cdb8c53880"
-  integrity sha512-BxbNGGNm0RyRYvUdHpIwv9IWzeM9XClbOxwoATuFdOE7ZE6wHL+HQ5T8hoPM+zHvmKzzsEqhgy0GrQ5X13afiQ==
-
-esutils@^2.0.2:
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.3.tgz#74d2eb4de0b8da1293711910d50775b9b710ef64"
-  integrity sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==
-
-events@1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/events/-/events-1.1.1.tgz#9ebdb7635ad099c70dcc4c2a1f5004288e8bd924"
-  integrity sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ=
 
 exec-sh@^0.3.2:
   version "0.3.6"
@@ -1838,17 +2179,16 @@ expect@^26.6.2:
     jest-message-util "^26.6.2"
     jest-regex-util "^26.0.0"
 
-expect@^27.0.6:
-  version "27.0.6"
-  resolved "https://registry.yarnpkg.com/expect/-/expect-27.0.6.tgz#a4d74fbe27222c718fff68ef49d78e26a8fd4c05"
-  integrity sha512-psNLt8j2kwg42jGBDSfAlU49CEZxejN1f1PlANWDZqIhBOVU/c2Pm888FcjWJzFewhIsNWfZJeLjUjtKGiPuSw==
+expect@^29.0.0, expect@^29.7.0:
+  version "29.7.0"
+  resolved "https://registry.yarnpkg.com/expect/-/expect-29.7.0.tgz#578874590dcb3214514084c08115d8aee61e11bc"
+  integrity sha512-2Zks0hf1VLFYI1kbh0I5jP3KHHyCHpkfyHBzsSXRFgl/Bg9mWYfMW8oD+PdMPlEwy5HNsR9JutYy6pMeOh61nw==
   dependencies:
-    "@jest/types" "^27.0.6"
-    ansi-styles "^5.0.0"
-    jest-get-type "^27.0.6"
-    jest-matcher-utils "^27.0.6"
-    jest-message-util "^27.0.6"
-    jest-regex-util "^27.0.6"
+    "@jest/expect-utils" "^29.7.0"
+    jest-get-type "^29.6.3"
+    jest-matcher-utils "^29.7.0"
+    jest-message-util "^29.7.0"
+    jest-util "^29.7.0"
 
 extend-shallow@^2.0.1:
   version "2.0.1"
@@ -1904,15 +2244,28 @@ fast-glob@^3.1.1:
     merge2 "^1.3.0"
     micromatch "^4.0.4"
 
-fast-json-stable-stringify@2.x, fast-json-stable-stringify@^2.0.0:
+fast-json-stable-stringify@2.x, fast-json-stable-stringify@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz#874bf69c6f404c2b5d99c481341399fd55892633"
   integrity sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==
 
-fast-levenshtein@~2.0.6:
-  version "2.0.6"
-  resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
-  integrity sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=
+fast-xml-builder@^1.1.7:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/fast-xml-builder/-/fast-xml-builder-1.2.0.tgz#abd2363145a7625d9789ad96da375fabe3cff28c"
+  integrity sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==
+  dependencies:
+    path-expression-matcher "^1.5.0"
+    xml-naming "^0.1.0"
+
+fast-xml-parser@5.7.3:
+  version "5.7.3"
+  resolved "https://registry.yarnpkg.com/fast-xml-parser/-/fast-xml-parser-5.7.3.tgz#309b04b08d835defc62ab657a0bb340c0e0fbe6a"
+  integrity sha512-C0AaNuC+mscy6vrAQKAc/rMq+zAPHodfHGZu4sGVehvAQt/JLG1O5zEcYcXSY5zSqr4YVgxsB+pHXTq0i7eDlg==
+  dependencies:
+    "@nodable/entities" "^2.1.0"
+    fast-xml-builder "^1.1.7"
+    path-expression-matcher "^1.5.0"
+    strnum "^2.2.3"
 
 fastq@^1.6.0:
   version "1.11.1"
@@ -1973,15 +2326,6 @@ for-in@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/for-in/-/for-in-1.0.2.tgz#81068d295a8142ec0ac726c6e2200c30fb6d5e80"
   integrity sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=
-
-form-data@^3.0.0:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/form-data/-/form-data-3.0.1.tgz#ebd53791b78356a99af9a300d4282c4d5eb9755f"
-  integrity sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==
-  dependencies:
-    asynckit "^0.4.0"
-    combined-stream "^1.0.8"
-    mime-types "^2.1.12"
 
 fp-ts@^2.6.7:
   version "2.12.1"
@@ -2077,7 +2421,7 @@ glob-parent@^5.1.2:
   dependencies:
     is-glob "^4.0.1"
 
-glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@^7.1.4:
+glob@^7.1.3, glob@^7.1.4:
   version "7.1.7"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.7.tgz#3b193e9233f01d42d0b3f78294bbeeb418f94a90"
   integrity sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==
@@ -2088,11 +2432,6 @@ glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@^7.1.4:
     minimatch "^3.0.4"
     once "^1.3.0"
     path-is-absolute "^1.0.0"
-
-globals@^11.1.0:
-  version "11.12.0"
-  resolved "https://registry.yarnpkg.com/globals/-/globals-11.12.0.tgz#ab8795338868a0babd8525758018c2a7eb95c42e"
-  integrity sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==
 
 globby@^11.0.0:
   version "11.0.4"
@@ -2111,10 +2450,27 @@ graceful-fs@^4.1.2, graceful-fs@^4.1.5, graceful-fs@^4.1.6, graceful-fs@^4.2.0, 
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.6.tgz#ff040b2b0853b23c3d31027523706f1885d76bee"
   integrity sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ==
 
+graceful-fs@^4.2.9:
+  version "4.2.11"
+  resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.11.tgz#4183e4e8bf08bb6e05bbb2f7d2e0c8f712ca40e3"
+  integrity sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==
+
 grapheme-splitter@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/grapheme-splitter/-/grapheme-splitter-1.0.4.tgz#9cf3a665c6247479896834af35cf1dbb4400767e"
   integrity sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ==
+
+handlebars@^4.7.9:
+  version "4.7.9"
+  resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.7.9.tgz#6f139082ab58dc4e5a0e51efe7db5ae890d56a0f"
+  integrity sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==
+  dependencies:
+    minimist "^1.2.5"
+    neo-async "^2.6.2"
+    source-map "^0.6.1"
+    wordwrap "^1.0.0"
+  optionalDependencies:
+    uglify-js "^3.1.4"
 
 hard-rejection@^2.1.0:
   version "2.1.0"
@@ -2174,34 +2530,10 @@ hosted-git-info@^2.1.4:
   resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.8.9.tgz#dffc0bf9a21c02209090f2aa69429e1414daf3f9"
   integrity sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==
 
-html-encoding-sniffer@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/html-encoding-sniffer/-/html-encoding-sniffer-2.0.1.tgz#42a6dc4fd33f00281176e8b23759ca4e4fa185f3"
-  integrity sha512-D5JbOMBIR/TVZkubHT+OyT2705QvogUW4IBn6nHd756OwieSF9aDYFj4dv6HHEVGYbHaLETa3WggZYWWMyy3ZQ==
-  dependencies:
-    whatwg-encoding "^1.0.5"
-
 html-escaper@^2.0.0:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/html-escaper/-/html-escaper-2.0.2.tgz#dfd60027da36a36dfcbe236262c00a5822681453"
   integrity sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==
-
-http-proxy-agent@^4.0.1:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/http-proxy-agent/-/http-proxy-agent-4.0.1.tgz#8a8c8ef7f5932ccf953c296ca8291b95aa74aa3a"
-  integrity sha512-k0zdNgqWTGA6aeIRVpvfVob4fL52dTfaehylg0Y4UvSySvOq/Y+BOyPrgpUrA7HylqvU8vIZGsRuXmspskV0Tg==
-  dependencies:
-    "@tootallnate/once" "1"
-    agent-base "6"
-    debug "4"
-
-https-proxy-agent@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz#e2a90542abb68a762e0a0850f6c9edadfd8506b2"
-  integrity sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==
-  dependencies:
-    agent-base "6"
-    debug "4"
 
 human-id@^1.0.2:
   version "1.0.2"
@@ -2213,22 +2545,12 @@ human-signals@^2.1.0:
   resolved "https://registry.yarnpkg.com/human-signals/-/human-signals-2.1.0.tgz#dc91fcba42e4d06e4abaed33b3e7a3c02f514ea0"
   integrity sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==
 
-iconv-lite@0.4.24, iconv-lite@^0.4.24:
+iconv-lite@^0.4.24:
   version "0.4.24"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"
   integrity sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==
   dependencies:
     safer-buffer ">= 2.1.2 < 3"
-
-ieee754@1.1.13:
-  version "1.1.13"
-  resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.1.13.tgz#ec168558e95aa181fd87d37f55c32bbcb6708b84"
-  integrity sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg==
-
-ieee754@^1.1.4:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.2.1.tgz#8eb7a10a63fff25d15a57b001586d177d1b0d352"
-  integrity sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==
 
 ignore@^5.1.4:
   version "5.1.8"
@@ -2311,13 +2633,6 @@ is-ci@^2.0.0:
   integrity sha512-YfJT7rkpQB0updsdHLGWrvhBJfcfzNNawYDNIyQXJz0IViGf75O8EBPKSdvw2rF+LGCsX4FZ8tcr3b19LcZq4w==
   dependencies:
     ci-info "^2.0.0"
-
-is-ci@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/is-ci/-/is-ci-3.0.0.tgz#c7e7be3c9d8eef7d0fa144390bd1e4b88dc4c994"
-  integrity sha512-kDXyttuLeslKAHYL/K28F2YkM3x5jvFPEw3yXbRptXydjD9rpLEz+C5K5iutY9ZiUu6AP41JdvRQwF4Iqs4ZCQ==
-  dependencies:
-    ci-info "^3.1.1"
 
 is-core-module@^2.2.0:
   version "2.4.0"
@@ -2421,11 +2736,6 @@ is-plain-object@^2.0.3, is-plain-object@^2.0.4:
   dependencies:
     isobject "^3.0.1"
 
-is-potential-custom-element-name@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz#171ed6f19e3ac554394edf78caa05784a45bebb5"
-  integrity sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==
-
 is-stream@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-1.1.0.tgz#12d4a3dd4e68e0b79ceb8dbc84173ae80d91ca44"
@@ -2443,17 +2753,12 @@ is-subdir@^1.1.1:
   dependencies:
     better-path-resolve "1.0.0"
 
-is-typedarray@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/is-typedarray/-/is-typedarray-1.0.0.tgz#e479c80858df0c1b11ddda6940f96011fcda4a9a"
-  integrity sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=
-
 is-windows@^1.0.0, is-windows@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/is-windows/-/is-windows-1.0.2.tgz#d1850eb9791ecd18e6182ce12a30f396634bb19d"
   integrity sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==
 
-isarray@1.0.0, isarray@^1.0.0:
+isarray@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11"
   integrity sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=
@@ -2480,15 +2785,32 @@ istanbul-lib-coverage@^3.0.0:
   resolved "https://registry.yarnpkg.com/istanbul-lib-coverage/-/istanbul-lib-coverage-3.0.0.tgz#f5944a37c70b550b02a78a5c3b2055b280cec8ec"
   integrity sha512-UiUIqxMgRDET6eR+o5HbfRYP1l0hqkWOs7vNxC/mggutCMUIhWMm8gAHb8tHlyfD3/l6rlgNA5cKdDzEAf6hEg==
 
-istanbul-lib-instrument@^4.0.0, istanbul-lib-instrument@^4.0.3:
-  version "4.0.3"
-  resolved "https://registry.yarnpkg.com/istanbul-lib-instrument/-/istanbul-lib-instrument-4.0.3.tgz#873c6fff897450118222774696a3f28902d77c1d"
-  integrity sha512-BXgQl9kf4WTCPCCpmFGoJkz/+uhvm7h7PFKUYxh7qarQd3ER33vHG//qaE8eN25l07YqZPpHXU9I09l/RD5aGQ==
+istanbul-lib-coverage@^3.2.0:
+  version "3.2.2"
+  resolved "https://registry.yarnpkg.com/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz#2d166c4b0644d43a39f04bf6c2edd1e585f31756"
+  integrity sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==
+
+istanbul-lib-instrument@^5.0.4:
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/istanbul-lib-instrument/-/istanbul-lib-instrument-5.2.1.tgz#d10c8885c2125574e1c231cacadf955675e1ce3d"
+  integrity sha512-pzqtp31nLv/XFOzXGuvhCb8qhjmTVo5vjVk19XE4CRlSWz0KoeJ3bw9XsA7nOp9YBf4qHjwBxkDzKcME/J29Yg==
   dependencies:
-    "@babel/core" "^7.7.5"
+    "@babel/core" "^7.12.3"
+    "@babel/parser" "^7.14.7"
     "@istanbuljs/schema" "^0.1.2"
-    istanbul-lib-coverage "^3.0.0"
+    istanbul-lib-coverage "^3.2.0"
     semver "^6.3.0"
+
+istanbul-lib-instrument@^6.0.0:
+  version "6.0.3"
+  resolved "https://registry.yarnpkg.com/istanbul-lib-instrument/-/istanbul-lib-instrument-6.0.3.tgz#fa15401df6c15874bcb2105f773325d78c666765"
+  integrity sha512-Vtgk7L/R2JHyyGW07spoFlB8/lpjiOLTjMdms6AFMraYt3BaJauod/NGrfnVG/y4Ix1JEuMRPDPEj2ua+zz1/Q==
+  dependencies:
+    "@babel/core" "^7.23.9"
+    "@babel/parser" "^7.23.9"
+    "@istanbuljs/schema" "^0.1.3"
+    istanbul-lib-coverage "^3.2.0"
+    semver "^7.5.4"
 
 istanbul-lib-report@^3.0.0:
   version "3.0.0"
@@ -2508,94 +2830,95 @@ istanbul-lib-source-maps@^4.0.0:
     istanbul-lib-coverage "^3.0.0"
     source-map "^0.6.1"
 
-istanbul-reports@^3.0.2:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/istanbul-reports/-/istanbul-reports-3.0.2.tgz#d593210e5000683750cb09fc0644e4b6e27fd53b"
-  integrity sha512-9tZvz7AiR3PEDNGiV9vIouQ/EAcqMXFmkcA1CDFTwOB98OZVDL0PH9glHotf5Ugp6GCOTypfzGWI/OqjWNCRUw==
+istanbul-reports@^3.1.3:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/istanbul-reports/-/istanbul-reports-3.2.0.tgz#cb4535162b5784aa623cee21a7252cf2c807ac93"
+  integrity sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==
   dependencies:
     html-escaper "^2.0.0"
     istanbul-lib-report "^3.0.0"
 
-jest-changed-files@^27.0.6:
-  version "27.0.6"
-  resolved "https://registry.yarnpkg.com/jest-changed-files/-/jest-changed-files-27.0.6.tgz#bed6183fcdea8a285482e3b50a9a7712d49a7a8b"
-  integrity sha512-BuL/ZDauaq5dumYh5y20sn4IISnf1P9A0TDswTxUi84ORGtVa86ApuBHqICL0vepqAnZiY6a7xeSPWv2/yy4eA==
+jest-changed-files@^29.7.0:
+  version "29.7.0"
+  resolved "https://registry.yarnpkg.com/jest-changed-files/-/jest-changed-files-29.7.0.tgz#1c06d07e77c78e1585d020424dedc10d6e17ac3a"
+  integrity sha512-fEArFiwf1BpQ+4bXSprcDc3/x4HSzL4al2tozwVpDFpsxALjLYdyiIK4e5Vz66GQJIbXJ82+35PtysofptNX2w==
   dependencies:
-    "@jest/types" "^27.0.6"
     execa "^5.0.0"
-    throat "^6.0.1"
+    jest-util "^29.7.0"
+    p-limit "^3.1.0"
 
-jest-circus@^27.0.6:
-  version "27.0.6"
-  resolved "https://registry.yarnpkg.com/jest-circus/-/jest-circus-27.0.6.tgz#dd4df17c4697db6a2c232aaad4e9cec666926668"
-  integrity sha512-OJlsz6BBeX9qR+7O9lXefWoc2m9ZqcZ5Ohlzz0pTEAG4xMiZUJoacY8f4YDHxgk0oKYxj277AfOk9w6hZYvi1Q==
+jest-circus@^29.7.0:
+  version "29.7.0"
+  resolved "https://registry.yarnpkg.com/jest-circus/-/jest-circus-29.7.0.tgz#b6817a45fcc835d8b16d5962d0c026473ee3668a"
+  integrity sha512-3E1nCMgipcTkCocFwM90XXQab9bS+GMsjdpmPrlelaxwD93Ad8iVEjX/vvHPdLPnFf+L40u+5+iutRdA1N9myw==
   dependencies:
-    "@jest/environment" "^27.0.6"
-    "@jest/test-result" "^27.0.6"
-    "@jest/types" "^27.0.6"
+    "@jest/environment" "^29.7.0"
+    "@jest/expect" "^29.7.0"
+    "@jest/test-result" "^29.7.0"
+    "@jest/types" "^29.6.3"
     "@types/node" "*"
     chalk "^4.0.0"
     co "^4.6.0"
-    dedent "^0.7.0"
-    expect "^27.0.6"
+    dedent "^1.0.0"
     is-generator-fn "^2.0.0"
-    jest-each "^27.0.6"
-    jest-matcher-utils "^27.0.6"
-    jest-message-util "^27.0.6"
-    jest-runtime "^27.0.6"
-    jest-snapshot "^27.0.6"
-    jest-util "^27.0.6"
-    pretty-format "^27.0.6"
+    jest-each "^29.7.0"
+    jest-matcher-utils "^29.7.0"
+    jest-message-util "^29.7.0"
+    jest-runtime "^29.7.0"
+    jest-snapshot "^29.7.0"
+    jest-util "^29.7.0"
+    p-limit "^3.1.0"
+    pretty-format "^29.7.0"
+    pure-rand "^6.0.0"
     slash "^3.0.0"
     stack-utils "^2.0.3"
-    throat "^6.0.1"
 
-jest-cli@^27.0.4:
-  version "27.0.6"
-  resolved "https://registry.yarnpkg.com/jest-cli/-/jest-cli-27.0.6.tgz#d021e5f4d86d6a212450d4c7b86cb219f1e6864f"
-  integrity sha512-qUUVlGb9fdKir3RDE+B10ULI+LQrz+MCflEH2UJyoUjoHHCbxDrMxSzjQAPUMsic4SncI62ofYCcAvW6+6rhhg==
+jest-cli@^29.7.0:
+  version "29.7.0"
+  resolved "https://registry.yarnpkg.com/jest-cli/-/jest-cli-29.7.0.tgz#5592c940798e0cae677eec169264f2d839a37995"
+  integrity sha512-OVVobw2IubN/GSYsxETi+gOe7Ka59EFMR/twOU3Jb2GnKKeMGJB5SGUUrEz3SFVmJASUdZUzy83sLNNQ2gZslg==
   dependencies:
-    "@jest/core" "^27.0.6"
-    "@jest/test-result" "^27.0.6"
-    "@jest/types" "^27.0.6"
+    "@jest/core" "^29.7.0"
+    "@jest/test-result" "^29.7.0"
+    "@jest/types" "^29.6.3"
     chalk "^4.0.0"
+    create-jest "^29.7.0"
     exit "^0.1.2"
-    graceful-fs "^4.2.4"
     import-local "^3.0.2"
-    jest-config "^27.0.6"
-    jest-util "^27.0.6"
-    jest-validate "^27.0.6"
-    prompts "^2.0.1"
-    yargs "^16.0.3"
+    jest-config "^29.7.0"
+    jest-util "^29.7.0"
+    jest-validate "^29.7.0"
+    yargs "^17.3.1"
 
-jest-config@^27.0.6:
-  version "27.0.6"
-  resolved "https://registry.yarnpkg.com/jest-config/-/jest-config-27.0.6.tgz#119fb10f149ba63d9c50621baa4f1f179500277f"
-  integrity sha512-JZRR3I1Plr2YxPBhgqRspDE2S5zprbga3swYNrvY3HfQGu7p/GjyLOqwrYad97tX3U3mzT53TPHVmozacfP/3w==
+jest-config@^29.7.0:
+  version "29.7.0"
+  resolved "https://registry.yarnpkg.com/jest-config/-/jest-config-29.7.0.tgz#bcbda8806dbcc01b1e316a46bb74085a84b0245f"
+  integrity sha512-uXbpfeQ7R6TZBqI3/TxCU4q4ttk3u0PJeC+E0zbfSoSjq6bJ7buBPxzQPL0ifrkY4DNu4JUdk0ImlBUYi840eQ==
   dependencies:
-    "@babel/core" "^7.1.0"
-    "@jest/test-sequencer" "^27.0.6"
-    "@jest/types" "^27.0.6"
-    babel-jest "^27.0.6"
+    "@babel/core" "^7.11.6"
+    "@jest/test-sequencer" "^29.7.0"
+    "@jest/types" "^29.6.3"
+    babel-jest "^29.7.0"
     chalk "^4.0.0"
+    ci-info "^3.2.0"
     deepmerge "^4.2.2"
-    glob "^7.1.1"
-    graceful-fs "^4.2.4"
-    is-ci "^3.0.0"
-    jest-circus "^27.0.6"
-    jest-environment-jsdom "^27.0.6"
-    jest-environment-node "^27.0.6"
-    jest-get-type "^27.0.6"
-    jest-jasmine2 "^27.0.6"
-    jest-regex-util "^27.0.6"
-    jest-resolve "^27.0.6"
-    jest-runner "^27.0.6"
-    jest-util "^27.0.6"
-    jest-validate "^27.0.6"
+    glob "^7.1.3"
+    graceful-fs "^4.2.9"
+    jest-circus "^29.7.0"
+    jest-environment-node "^29.7.0"
+    jest-get-type "^29.6.3"
+    jest-regex-util "^29.6.3"
+    jest-resolve "^29.7.0"
+    jest-runner "^29.7.0"
+    jest-util "^29.7.0"
+    jest-validate "^29.7.0"
     micromatch "^4.0.4"
-    pretty-format "^27.0.6"
+    parse-json "^5.2.0"
+    pretty-format "^29.7.0"
+    slash "^3.0.0"
+    strip-json-comments "^3.1.1"
 
-jest-diff@^26.0.0, jest-diff@^26.1.0, jest-diff@^26.6.2:
+jest-diff@^26.1.0, jest-diff@^26.6.2:
   version "26.6.2"
   resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-26.6.2.tgz#1aa7468b52c3a68d7d5c5fdcdfcd5e49bd164394"
   integrity sha512-6m+9Z3Gv9wN0WFVasqjCL/06+EFCMTqDEUl/b87HYK2rAPTyfz4ZIuSlPhY51PIQRWx5TaxeF1qmXKe9gfN3sA==
@@ -2605,83 +2928,55 @@ jest-diff@^26.0.0, jest-diff@^26.1.0, jest-diff@^26.6.2:
     jest-get-type "^26.3.0"
     pretty-format "^26.6.2"
 
-jest-diff@^27.0.6:
-  version "27.0.6"
-  resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-27.0.6.tgz#4a7a19ee6f04ad70e0e3388f35829394a44c7b5e"
-  integrity sha512-Z1mqgkTCSYaFgwTlP/NUiRzdqgxmmhzHY1Tq17zL94morOHfHu3K4bgSgl+CR4GLhpV8VxkuOYuIWnQ9LnFqmg==
+jest-diff@^29.7.0:
+  version "29.7.0"
+  resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-29.7.0.tgz#017934a66ebb7ecf6f205e84699be10afd70458a"
+  integrity sha512-LMIgiIrhigmPrs03JHpxUh2yISK3vLFPkAodPeo0+BuF7wA2FoQbkEg1u8gBYBThncu7e1oEDUfIXVuTqLRUjw==
   dependencies:
     chalk "^4.0.0"
-    diff-sequences "^27.0.6"
-    jest-get-type "^27.0.6"
-    pretty-format "^27.0.6"
+    diff-sequences "^29.6.3"
+    jest-get-type "^29.6.3"
+    pretty-format "^29.7.0"
 
-jest-diff@^27.5.1:
-  version "27.5.1"
-  resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-27.5.1.tgz#a07f5011ac9e6643cf8a95a462b7b1ecf6680def"
-  integrity sha512-m0NvkX55LDt9T4mctTEgnZk3fmEg3NRYutvMPWM/0iPnkFj2wIeF45O1718cMSOFO1vINkqmxqD8vE37uTEbqw==
-  dependencies:
-    chalk "^4.0.0"
-    diff-sequences "^27.5.1"
-    jest-get-type "^27.5.1"
-    pretty-format "^27.5.1"
-
-jest-docblock@^27.0.6:
-  version "27.0.6"
-  resolved "https://registry.yarnpkg.com/jest-docblock/-/jest-docblock-27.0.6.tgz#cc78266acf7fe693ca462cbbda0ea4e639e4e5f3"
-  integrity sha512-Fid6dPcjwepTFraz0YxIMCi7dejjJ/KL9FBjPYhBp4Sv1Y9PdhImlKZqYU555BlN4TQKaTc+F2Av1z+anVyGkA==
+jest-docblock@^29.7.0:
+  version "29.7.0"
+  resolved "https://registry.yarnpkg.com/jest-docblock/-/jest-docblock-29.7.0.tgz#8fddb6adc3cdc955c93e2a87f61cfd350d5d119a"
+  integrity sha512-q617Auw3A612guyaFgsbFeYpNP5t2aoUNLwBUbc/0kD1R4t9ixDbyFTHd1nok4epoVFpr7PmeWHrhvuV3XaJ4g==
   dependencies:
     detect-newline "^3.0.0"
 
-jest-each@^27.0.6:
-  version "27.0.6"
-  resolved "https://registry.yarnpkg.com/jest-each/-/jest-each-27.0.6.tgz#cee117071b04060158dc8d9a66dc50ad40ef453b"
-  integrity sha512-m6yKcV3bkSWrUIjxkE9OC0mhBZZdhovIW5ergBYirqnkLXkyEn3oUUF/QZgyecA1cF1QFyTE8bRRl8Tfg1pfLA==
+jest-each@^29.7.0:
+  version "29.7.0"
+  resolved "https://registry.yarnpkg.com/jest-each/-/jest-each-29.7.0.tgz#162a9b3f2328bdd991beaabffbb74745e56577d1"
+  integrity sha512-gns+Er14+ZrEoC5fhOfYCY1LOHHr0TI+rQUHZS8Ttw2l7gl+80eHc/gFf2Ktkw0+SIACDTeWvpFcv3B04VembQ==
   dependencies:
-    "@jest/types" "^27.0.6"
+    "@jest/types" "^29.6.3"
     chalk "^4.0.0"
-    jest-get-type "^27.0.6"
-    jest-util "^27.0.6"
-    pretty-format "^27.0.6"
+    jest-get-type "^29.6.3"
+    jest-util "^29.7.0"
+    pretty-format "^29.7.0"
 
-jest-environment-jsdom@^27.0.6:
-  version "27.0.6"
-  resolved "https://registry.yarnpkg.com/jest-environment-jsdom/-/jest-environment-jsdom-27.0.6.tgz#f66426c4c9950807d0a9f209c590ce544f73291f"
-  integrity sha512-FvetXg7lnXL9+78H+xUAsra3IeZRTiegA3An01cWeXBspKXUhAwMM9ycIJ4yBaR0L7HkoMPaZsozCLHh4T8fuw==
+jest-environment-node@^29.7.0:
+  version "29.7.0"
+  resolved "https://registry.yarnpkg.com/jest-environment-node/-/jest-environment-node-29.7.0.tgz#0b93e111dda8ec120bc8300e6d1fb9576e164376"
+  integrity sha512-DOSwCRqXirTOyheM+4d5YZOrWcdu0LNZ87ewUoywbcb2XR4wKgqiG8vNeYwhjFMbEkfju7wx2GYH0P2gevGvFw==
   dependencies:
-    "@jest/environment" "^27.0.6"
-    "@jest/fake-timers" "^27.0.6"
-    "@jest/types" "^27.0.6"
+    "@jest/environment" "^29.7.0"
+    "@jest/fake-timers" "^29.7.0"
+    "@jest/types" "^29.6.3"
     "@types/node" "*"
-    jest-mock "^27.0.6"
-    jest-util "^27.0.6"
-    jsdom "^16.6.0"
-
-jest-environment-node@^27.0.6:
-  version "27.0.6"
-  resolved "https://registry.yarnpkg.com/jest-environment-node/-/jest-environment-node-27.0.6.tgz#a6699b7ceb52e8d68138b9808b0c404e505f3e07"
-  integrity sha512-+Vi6yLrPg/qC81jfXx3IBlVnDTI6kmRr08iVa2hFCWmJt4zha0XW7ucQltCAPhSR0FEKEoJ3i+W4E6T0s9is0w==
-  dependencies:
-    "@jest/environment" "^27.0.6"
-    "@jest/fake-timers" "^27.0.6"
-    "@jest/types" "^27.0.6"
-    "@types/node" "*"
-    jest-mock "^27.0.6"
-    jest-util "^27.0.6"
+    jest-mock "^29.7.0"
+    jest-util "^29.7.0"
 
 jest-get-type@^26.3.0:
   version "26.3.0"
   resolved "https://registry.yarnpkg.com/jest-get-type/-/jest-get-type-26.3.0.tgz#e97dc3c3f53c2b406ca7afaed4493b1d099199e0"
   integrity sha512-TpfaviN1R2pQWkIihlfEanwOXK0zcxrKEE4MlU6Tn7keoXdN6/3gK/xl0yEh8DOunn5pOVGKf8hB4R9gVh04ig==
 
-jest-get-type@^27.0.6:
-  version "27.0.6"
-  resolved "https://registry.yarnpkg.com/jest-get-type/-/jest-get-type-27.0.6.tgz#0eb5c7f755854279ce9b68a9f1a4122f69047cfe"
-  integrity sha512-XTkK5exIeUbbveehcSR8w0bhH+c0yloW/Wpl+9vZrjzztCPWrxhHwkIFpZzCt71oRBsgxmuUfxEqOYoZI2macg==
-
-jest-get-type@^27.5.1:
-  version "27.5.1"
-  resolved "https://registry.yarnpkg.com/jest-get-type/-/jest-get-type-27.5.1.tgz#3cd613c507b0f7ace013df407a1c1cd578bcb4f1"
-  integrity sha512-2KY95ksYSaK7DMBWQn6dQz3kqAf3BB64y2udeG+hv4KfSOb9qwcYQstTJc1KCbsix+wLZWZYN8t7nwX3GOBLRw==
+jest-get-type@^29.6.3:
+  version "29.6.3"
+  resolved "https://registry.yarnpkg.com/jest-get-type/-/jest-get-type-29.6.3.tgz#36f499fdcea197c1045a127319c0481723908fd1"
+  integrity sha512-zrteXnqYxfQh7l5FHyL38jL39di8H8rHoecLH3JNxH3BwOrBsNeabdap5e0I23lD4HHI8W5VFBZqG4Eaq5LNcw==
 
 jest-haste-map@^26.6.2:
   version "26.6.2"
@@ -2704,57 +2999,32 @@ jest-haste-map@^26.6.2:
   optionalDependencies:
     fsevents "^2.1.2"
 
-jest-haste-map@^27.0.6:
-  version "27.0.6"
-  resolved "https://registry.yarnpkg.com/jest-haste-map/-/jest-haste-map-27.0.6.tgz#4683a4e68f6ecaa74231679dca237279562c8dc7"
-  integrity sha512-4ldjPXX9h8doB2JlRzg9oAZ2p6/GpQUNAeiYXqcpmrKbP0Qev0wdZlxSMOmz8mPOEnt4h6qIzXFLDi8RScX/1w==
+jest-haste-map@^29.7.0:
+  version "29.7.0"
+  resolved "https://registry.yarnpkg.com/jest-haste-map/-/jest-haste-map-29.7.0.tgz#3c2396524482f5a0506376e6c858c3bbcc17b104"
+  integrity sha512-fP8u2pyfqx0K1rGn1R9pyE0/KTn+G7PxktWidOBTqFPLYX0b9ksaMFkhK5vrS3DVun09pckLdlx90QthlW7AmA==
   dependencies:
-    "@jest/types" "^27.0.6"
-    "@types/graceful-fs" "^4.1.2"
+    "@jest/types" "^29.6.3"
+    "@types/graceful-fs" "^4.1.3"
     "@types/node" "*"
     anymatch "^3.0.3"
     fb-watchman "^2.0.0"
-    graceful-fs "^4.2.4"
-    jest-regex-util "^27.0.6"
-    jest-serializer "^27.0.6"
-    jest-util "^27.0.6"
-    jest-worker "^27.0.6"
+    graceful-fs "^4.2.9"
+    jest-regex-util "^29.6.3"
+    jest-util "^29.7.0"
+    jest-worker "^29.7.0"
     micromatch "^4.0.4"
-    walker "^1.0.7"
+    walker "^1.0.8"
   optionalDependencies:
     fsevents "^2.3.2"
 
-jest-jasmine2@^27.0.6:
-  version "27.0.6"
-  resolved "https://registry.yarnpkg.com/jest-jasmine2/-/jest-jasmine2-27.0.6.tgz#fd509a9ed3d92bd6edb68a779f4738b100655b37"
-  integrity sha512-cjpH2sBy+t6dvCeKBsHpW41mjHzXgsavaFMp+VWRf0eR4EW8xASk1acqmljFtK2DgyIECMv2yCdY41r2l1+4iA==
+jest-leak-detector@^29.7.0:
+  version "29.7.0"
+  resolved "https://registry.yarnpkg.com/jest-leak-detector/-/jest-leak-detector-29.7.0.tgz#5b7ec0dadfdfec0ca383dc9aa016d36b5ea4c728"
+  integrity sha512-kYA8IJcSYtST2BY9I+SMC32nDpBT3J2NvWJx8+JCuCdl/CR1I4EKUJROiP8XtCcxqgTTBGJNdbB1A8XRKbTetw==
   dependencies:
-    "@babel/traverse" "^7.1.0"
-    "@jest/environment" "^27.0.6"
-    "@jest/source-map" "^27.0.6"
-    "@jest/test-result" "^27.0.6"
-    "@jest/types" "^27.0.6"
-    "@types/node" "*"
-    chalk "^4.0.0"
-    co "^4.6.0"
-    expect "^27.0.6"
-    is-generator-fn "^2.0.0"
-    jest-each "^27.0.6"
-    jest-matcher-utils "^27.0.6"
-    jest-message-util "^27.0.6"
-    jest-runtime "^27.0.6"
-    jest-snapshot "^27.0.6"
-    jest-util "^27.0.6"
-    pretty-format "^27.0.6"
-    throat "^6.0.1"
-
-jest-leak-detector@^27.0.6:
-  version "27.0.6"
-  resolved "https://registry.yarnpkg.com/jest-leak-detector/-/jest-leak-detector-27.0.6.tgz#545854275f85450d4ef4b8fe305ca2a26450450f"
-  integrity sha512-2/d6n2wlH5zEcdctX4zdbgX8oM61tb67PQt4Xh8JFAIy6LRKUnX528HulkaG6nD5qDl5vRV1NXejCe1XRCH5gQ==
-  dependencies:
-    jest-get-type "^27.0.6"
-    pretty-format "^27.0.6"
+    jest-get-type "^29.6.3"
+    pretty-format "^29.7.0"
 
 jest-matcher-utils@^26.6.2:
   version "26.6.2"
@@ -2766,25 +3036,15 @@ jest-matcher-utils@^26.6.2:
     jest-get-type "^26.3.0"
     pretty-format "^26.6.2"
 
-jest-matcher-utils@^27.0.0:
-  version "27.5.1"
-  resolved "https://registry.yarnpkg.com/jest-matcher-utils/-/jest-matcher-utils-27.5.1.tgz#9c0cdbda8245bc22d2331729d1091308b40cf8ab"
-  integrity sha512-z2uTx/T6LBaCoNWNFWwChLBKYxTMcGBRjAt+2SbP929/Fflb9aa5LGma654Rz8z9HLxsrUaYzxE9T/EFIL/PAw==
+jest-matcher-utils@^29.7.0:
+  version "29.7.0"
+  resolved "https://registry.yarnpkg.com/jest-matcher-utils/-/jest-matcher-utils-29.7.0.tgz#ae8fec79ff249fd592ce80e3ee474e83a6c44f12"
+  integrity sha512-sBkD+Xi9DtcChsI3L3u0+N0opgPYnCRPtGcQYrgXmR+hmt/fYfWAL0xRXYU8eWOdfuLgBe0YCW3AFtnRLagq/g==
   dependencies:
     chalk "^4.0.0"
-    jest-diff "^27.5.1"
-    jest-get-type "^27.5.1"
-    pretty-format "^27.5.1"
-
-jest-matcher-utils@^27.0.6:
-  version "27.0.6"
-  resolved "https://registry.yarnpkg.com/jest-matcher-utils/-/jest-matcher-utils-27.0.6.tgz#2a8da1e86c620b39459f4352eaa255f0d43e39a9"
-  integrity sha512-OFgF2VCQx9vdPSYTHWJ9MzFCehs20TsyFi6bIHbk5V1u52zJOnvF0Y/65z3GLZHKRuTgVPY4Z6LVePNahaQ+tA==
-  dependencies:
-    chalk "^4.0.0"
-    jest-diff "^27.0.6"
-    jest-get-type "^27.0.6"
-    pretty-format "^27.0.6"
+    jest-diff "^29.7.0"
+    jest-get-type "^29.6.3"
+    pretty-format "^29.7.0"
 
 jest-message-util@^26.6.2:
   version "26.6.2"
@@ -2801,28 +3061,29 @@ jest-message-util@^26.6.2:
     slash "^3.0.0"
     stack-utils "^2.0.2"
 
-jest-message-util@^27.0.6:
-  version "27.0.6"
-  resolved "https://registry.yarnpkg.com/jest-message-util/-/jest-message-util-27.0.6.tgz#158bcdf4785706492d164a39abca6a14da5ab8b5"
-  integrity sha512-rBxIs2XK7rGy+zGxgi+UJKP6WqQ+KrBbD1YMj517HYN3v2BG66t3Xan3FWqYHKZwjdB700KiAJ+iES9a0M+ixw==
+jest-message-util@^29.7.0:
+  version "29.7.0"
+  resolved "https://registry.yarnpkg.com/jest-message-util/-/jest-message-util-29.7.0.tgz#8bc392e204e95dfe7564abbe72a404e28e51f7f3"
+  integrity sha512-GBEV4GRADeP+qtB2+6u61stea8mGcOT4mCtrYISZwfu9/ISHFJ/5zOMXYbpBE9RsS5+Gb63DW4FgmnKJ79Kf6w==
   dependencies:
     "@babel/code-frame" "^7.12.13"
-    "@jest/types" "^27.0.6"
+    "@jest/types" "^29.6.3"
     "@types/stack-utils" "^2.0.0"
     chalk "^4.0.0"
-    graceful-fs "^4.2.4"
+    graceful-fs "^4.2.9"
     micromatch "^4.0.4"
-    pretty-format "^27.0.6"
+    pretty-format "^29.7.0"
     slash "^3.0.0"
     stack-utils "^2.0.3"
 
-jest-mock@^27.0.6:
-  version "27.0.6"
-  resolved "https://registry.yarnpkg.com/jest-mock/-/jest-mock-27.0.6.tgz#0efdd40851398307ba16778728f6d34d583e3467"
-  integrity sha512-lzBETUoK8cSxts2NYXSBWT+EJNzmUVtVVwS1sU9GwE1DLCfGsngg+ZVSIe0yd0ZSm+y791esiuo+WSwpXJQ5Bw==
+jest-mock@^29.7.0:
+  version "29.7.0"
+  resolved "https://registry.yarnpkg.com/jest-mock/-/jest-mock-29.7.0.tgz#4e836cf60e99c6fcfabe9f99d017f3fdd50a6347"
+  integrity sha512-ITOMZn+UkYS4ZFh83xYAOzWStloNzJFO2s8DWrE4lhtGD+AorgnbkiKERe4wQVBydIGPx059g6riW5Btp6Llnw==
   dependencies:
-    "@jest/types" "^27.0.6"
+    "@jest/types" "^29.6.3"
     "@types/node" "*"
+    jest-util "^29.7.0"
 
 jest-pnp-resolver@^1.2.2:
   version "1.2.2"
@@ -2834,19 +3095,18 @@ jest-regex-util@^26.0.0:
   resolved "https://registry.yarnpkg.com/jest-regex-util/-/jest-regex-util-26.0.0.tgz#d25e7184b36e39fd466c3bc41be0971e821fee28"
   integrity sha512-Gv3ZIs/nA48/Zvjrl34bf+oD76JHiGDUxNOVgUjh3j890sblXryjY4rss71fPtD/njchl6PSE2hIhvyWa1eT0A==
 
-jest-regex-util@^27.0.6:
-  version "27.0.6"
-  resolved "https://registry.yarnpkg.com/jest-regex-util/-/jest-regex-util-27.0.6.tgz#02e112082935ae949ce5d13b2675db3d8c87d9c5"
-  integrity sha512-SUhPzBsGa1IKm8hx2F4NfTGGp+r7BXJ4CulsZ1k2kI+mGLG+lxGrs76veN2LF/aUdGosJBzKgXmNCw+BzFqBDQ==
+jest-regex-util@^29.6.3:
+  version "29.6.3"
+  resolved "https://registry.yarnpkg.com/jest-regex-util/-/jest-regex-util-29.6.3.tgz#4a556d9c776af68e1c5f48194f4d0327d24e8a52"
+  integrity sha512-KJJBsRCyyLNWCNBOvZyRDnAIfUiRJ8v+hOBQYGn8gDyF3UegwiP4gwRR3/SDa42g1YbVycTidUF3rKjyLFDWbg==
 
-jest-resolve-dependencies@^27.0.6:
-  version "27.0.6"
-  resolved "https://registry.yarnpkg.com/jest-resolve-dependencies/-/jest-resolve-dependencies-27.0.6.tgz#3e619e0ef391c3ecfcf6ef4056207a3d2be3269f"
-  integrity sha512-mg9x9DS3BPAREWKCAoyg3QucCr0n6S8HEEsqRCKSPjPcu9HzRILzhdzY3imsLoZWeosEbJZz6TKasveczzpJZA==
+jest-resolve-dependencies@^29.7.0:
+  version "29.7.0"
+  resolved "https://registry.yarnpkg.com/jest-resolve-dependencies/-/jest-resolve-dependencies-29.7.0.tgz#1b04f2c095f37fc776ff40803dc92921b1e88428"
+  integrity sha512-un0zD/6qxJ+S0et7WxeI3H5XSe9lTBBR7bOHCHXkKR6luG5mwDDlIzVQ0V5cZCuoTgEdcdwzTghYkTWfubi+nA==
   dependencies:
-    "@jest/types" "^27.0.6"
-    jest-regex-util "^27.0.6"
-    jest-snapshot "^27.0.6"
+    jest-regex-util "^29.6.3"
+    jest-snapshot "^29.7.0"
 
 jest-resolve@^26.6.2:
   version "26.6.2"
@@ -2862,93 +3122,80 @@ jest-resolve@^26.6.2:
     resolve "^1.18.1"
     slash "^3.0.0"
 
-jest-resolve@^27.0.6:
-  version "27.0.6"
-  resolved "https://registry.yarnpkg.com/jest-resolve/-/jest-resolve-27.0.6.tgz#e90f436dd4f8fbf53f58a91c42344864f8e55bff"
-  integrity sha512-yKmIgw2LgTh7uAJtzv8UFHGF7Dm7XfvOe/LQ3Txv101fLM8cx2h1QVwtSJ51Q/SCxpIiKfVn6G2jYYMDNHZteA==
+jest-resolve@^29.7.0:
+  version "29.7.0"
+  resolved "https://registry.yarnpkg.com/jest-resolve/-/jest-resolve-29.7.0.tgz#64d6a8992dd26f635ab0c01e5eef4399c6bcbc30"
+  integrity sha512-IOVhZSrg+UvVAshDSDtHyFCCBUl/Q3AAJv8iZ6ZjnZ74xzvwuzLXid9IIIPgTnY62SJjfuupMKZsZQRsCvxEgA==
   dependencies:
-    "@jest/types" "^27.0.6"
     chalk "^4.0.0"
-    escalade "^3.1.1"
-    graceful-fs "^4.2.4"
+    graceful-fs "^4.2.9"
+    jest-haste-map "^29.7.0"
     jest-pnp-resolver "^1.2.2"
-    jest-util "^27.0.6"
-    jest-validate "^27.0.6"
+    jest-util "^29.7.0"
+    jest-validate "^29.7.0"
     resolve "^1.20.0"
+    resolve.exports "^2.0.0"
     slash "^3.0.0"
 
-jest-runner@^27.0.6:
-  version "27.0.6"
-  resolved "https://registry.yarnpkg.com/jest-runner/-/jest-runner-27.0.6.tgz#1325f45055539222bbc7256a6976e993ad2f9520"
-  integrity sha512-W3Bz5qAgaSChuivLn+nKOgjqNxM7O/9JOJoKDCqThPIg2sH/d4A/lzyiaFgnb9V1/w29Le11NpzTJSzga1vyYQ==
+jest-runner@^29.7.0:
+  version "29.7.0"
+  resolved "https://registry.yarnpkg.com/jest-runner/-/jest-runner-29.7.0.tgz#809af072d408a53dcfd2e849a4c976d3132f718e"
+  integrity sha512-fsc4N6cPCAahybGBfTRcq5wFR6fpLznMg47sY5aDpsoejOcVYFb07AHuSnR0liMcPTgBsA3ZJL6kFOjPdoNipQ==
   dependencies:
-    "@jest/console" "^27.0.6"
-    "@jest/environment" "^27.0.6"
-    "@jest/test-result" "^27.0.6"
-    "@jest/transform" "^27.0.6"
-    "@jest/types" "^27.0.6"
+    "@jest/console" "^29.7.0"
+    "@jest/environment" "^29.7.0"
+    "@jest/test-result" "^29.7.0"
+    "@jest/transform" "^29.7.0"
+    "@jest/types" "^29.6.3"
     "@types/node" "*"
     chalk "^4.0.0"
-    emittery "^0.8.1"
-    exit "^0.1.2"
-    graceful-fs "^4.2.4"
-    jest-docblock "^27.0.6"
-    jest-environment-jsdom "^27.0.6"
-    jest-environment-node "^27.0.6"
-    jest-haste-map "^27.0.6"
-    jest-leak-detector "^27.0.6"
-    jest-message-util "^27.0.6"
-    jest-resolve "^27.0.6"
-    jest-runtime "^27.0.6"
-    jest-util "^27.0.6"
-    jest-worker "^27.0.6"
-    source-map-support "^0.5.6"
-    throat "^6.0.1"
+    emittery "^0.13.1"
+    graceful-fs "^4.2.9"
+    jest-docblock "^29.7.0"
+    jest-environment-node "^29.7.0"
+    jest-haste-map "^29.7.0"
+    jest-leak-detector "^29.7.0"
+    jest-message-util "^29.7.0"
+    jest-resolve "^29.7.0"
+    jest-runtime "^29.7.0"
+    jest-util "^29.7.0"
+    jest-watcher "^29.7.0"
+    jest-worker "^29.7.0"
+    p-limit "^3.1.0"
+    source-map-support "0.5.13"
 
-jest-runtime@^27.0.6:
-  version "27.0.6"
-  resolved "https://registry.yarnpkg.com/jest-runtime/-/jest-runtime-27.0.6.tgz#45877cfcd386afdd4f317def551fc369794c27c9"
-  integrity sha512-BhvHLRVfKibYyqqEFkybsznKwhrsu7AWx2F3y9G9L95VSIN3/ZZ9vBpm/XCS2bS+BWz3sSeNGLzI3TVQ0uL85Q==
+jest-runtime@^29.7.0:
+  version "29.7.0"
+  resolved "https://registry.yarnpkg.com/jest-runtime/-/jest-runtime-29.7.0.tgz#efecb3141cf7d3767a3a0cc8f7c9990587d3d817"
+  integrity sha512-gUnLjgwdGqW7B4LvOIkbKs9WGbn+QLqRQQ9juC6HndeDiezIwhDP+mhMwHWCEcfQ5RUXa6OPnFF8BJh5xegwwQ==
   dependencies:
-    "@jest/console" "^27.0.6"
-    "@jest/environment" "^27.0.6"
-    "@jest/fake-timers" "^27.0.6"
-    "@jest/globals" "^27.0.6"
-    "@jest/source-map" "^27.0.6"
-    "@jest/test-result" "^27.0.6"
-    "@jest/transform" "^27.0.6"
-    "@jest/types" "^27.0.6"
-    "@types/yargs" "^16.0.0"
+    "@jest/environment" "^29.7.0"
+    "@jest/fake-timers" "^29.7.0"
+    "@jest/globals" "^29.7.0"
+    "@jest/source-map" "^29.6.3"
+    "@jest/test-result" "^29.7.0"
+    "@jest/transform" "^29.7.0"
+    "@jest/types" "^29.6.3"
+    "@types/node" "*"
     chalk "^4.0.0"
     cjs-module-lexer "^1.0.0"
     collect-v8-coverage "^1.0.0"
-    exit "^0.1.2"
     glob "^7.1.3"
-    graceful-fs "^4.2.4"
-    jest-haste-map "^27.0.6"
-    jest-message-util "^27.0.6"
-    jest-mock "^27.0.6"
-    jest-regex-util "^27.0.6"
-    jest-resolve "^27.0.6"
-    jest-snapshot "^27.0.6"
-    jest-util "^27.0.6"
-    jest-validate "^27.0.6"
+    graceful-fs "^4.2.9"
+    jest-haste-map "^29.7.0"
+    jest-message-util "^29.7.0"
+    jest-mock "^29.7.0"
+    jest-regex-util "^29.6.3"
+    jest-resolve "^29.7.0"
+    jest-snapshot "^29.7.0"
+    jest-util "^29.7.0"
     slash "^3.0.0"
     strip-bom "^4.0.0"
-    yargs "^16.0.3"
 
 jest-serializer@^26.6.2:
   version "26.6.2"
   resolved "https://registry.yarnpkg.com/jest-serializer/-/jest-serializer-26.6.2.tgz#d139aafd46957d3a448f3a6cdabe2919ba0742d1"
   integrity sha512-S5wqyz0DXnNJPd/xfIzZ5Xnp1HrJWBczg8mMfMpN78OJ5eDxXyf+Ygld9wX1DnUWbIbhM1YDY95NjR4CBXkb2g==
-  dependencies:
-    "@types/node" "*"
-    graceful-fs "^4.2.4"
-
-jest-serializer@^27.0.6:
-  version "27.0.6"
-  resolved "https://registry.yarnpkg.com/jest-serializer/-/jest-serializer-27.0.6.tgz#93a6c74e0132b81a2d54623251c46c498bb5bec1"
-  integrity sha512-PtGdVK9EGC7dsaziskfqaAPib6wTViY3G8E5wz9tLVPhHyiDNTZn/xjZ4khAw+09QkoOVpn7vF5nPSN6dtBexA==
   dependencies:
     "@types/node" "*"
     graceful-fs "^4.2.4"
@@ -2975,35 +3222,31 @@ jest-snapshot@^26.1.0:
     pretty-format "^26.6.2"
     semver "^7.3.2"
 
-jest-snapshot@^27.0.6:
-  version "27.0.6"
-  resolved "https://registry.yarnpkg.com/jest-snapshot/-/jest-snapshot-27.0.6.tgz#f4e6b208bd2e92e888344d78f0f650bcff05a4bf"
-  integrity sha512-NTHaz8He+ATUagUgE7C/UtFcRoHqR2Gc+KDfhQIyx+VFgwbeEMjeP+ILpUTLosZn/ZtbNdCF5LkVnN/l+V751A==
+jest-snapshot@^29.7.0:
+  version "29.7.0"
+  resolved "https://registry.yarnpkg.com/jest-snapshot/-/jest-snapshot-29.7.0.tgz#c2c574c3f51865da1bb329036778a69bf88a6be5"
+  integrity sha512-Rm0BMWtxBcioHr1/OX5YCP8Uov4riHvKPknOGs804Zg9JGZgmIBkbtlxJC/7Z4msKYVbIJtfU+tKb8xlYNfdkw==
   dependencies:
-    "@babel/core" "^7.7.2"
+    "@babel/core" "^7.11.6"
     "@babel/generator" "^7.7.2"
-    "@babel/parser" "^7.7.2"
+    "@babel/plugin-syntax-jsx" "^7.7.2"
     "@babel/plugin-syntax-typescript" "^7.7.2"
-    "@babel/traverse" "^7.7.2"
-    "@babel/types" "^7.0.0"
-    "@jest/transform" "^27.0.6"
-    "@jest/types" "^27.0.6"
-    "@types/babel__traverse" "^7.0.4"
-    "@types/prettier" "^2.1.5"
+    "@babel/types" "^7.3.3"
+    "@jest/expect-utils" "^29.7.0"
+    "@jest/transform" "^29.7.0"
+    "@jest/types" "^29.6.3"
     babel-preset-current-node-syntax "^1.0.0"
     chalk "^4.0.0"
-    expect "^27.0.6"
-    graceful-fs "^4.2.4"
-    jest-diff "^27.0.6"
-    jest-get-type "^27.0.6"
-    jest-haste-map "^27.0.6"
-    jest-matcher-utils "^27.0.6"
-    jest-message-util "^27.0.6"
-    jest-resolve "^27.0.6"
-    jest-util "^27.0.6"
+    expect "^29.7.0"
+    graceful-fs "^4.2.9"
+    jest-diff "^29.7.0"
+    jest-get-type "^29.6.3"
+    jest-matcher-utils "^29.7.0"
+    jest-message-util "^29.7.0"
+    jest-util "^29.7.0"
     natural-compare "^1.4.0"
-    pretty-format "^27.0.6"
-    semver "^7.3.2"
+    pretty-format "^29.7.0"
+    semver "^7.5.3"
 
 jest-util@^26.6.2:
   version "26.6.2"
@@ -3017,41 +3260,42 @@ jest-util@^26.6.2:
     is-ci "^2.0.0"
     micromatch "^4.0.2"
 
-jest-util@^27.0.0, jest-util@^27.0.6:
-  version "27.0.6"
-  resolved "https://registry.yarnpkg.com/jest-util/-/jest-util-27.0.6.tgz#e8e04eec159de2f4d5f57f795df9cdc091e50297"
-  integrity sha512-1JjlaIh+C65H/F7D11GNkGDDZtDfMEM8EBXsvd+l/cxtgQ6QhxuloOaiayt89DxUvDarbVhqI98HhgrM1yliFQ==
+jest-util@^29.7.0:
+  version "29.7.0"
+  resolved "https://registry.yarnpkg.com/jest-util/-/jest-util-29.7.0.tgz#23c2b62bfb22be82b44de98055802ff3710fc0bc"
+  integrity sha512-z6EbKajIpqGKU56y5KBUgy1dt1ihhQJgWzUlZHArA/+X2ad7Cb5iF+AK1EWVL/Bo7Rz9uurpqw6SiBCefUbCGA==
   dependencies:
-    "@jest/types" "^27.0.6"
+    "@jest/types" "^29.6.3"
     "@types/node" "*"
     chalk "^4.0.0"
-    graceful-fs "^4.2.4"
-    is-ci "^3.0.0"
+    ci-info "^3.2.0"
+    graceful-fs "^4.2.9"
     picomatch "^2.2.3"
 
-jest-validate@^27.0.6:
-  version "27.0.6"
-  resolved "https://registry.yarnpkg.com/jest-validate/-/jest-validate-27.0.6.tgz#930a527c7a951927df269f43b2dc23262457e2a6"
-  integrity sha512-yhZZOaMH3Zg6DC83n60pLmdU1DQE46DW+KLozPiPbSbPhlXXaiUTDlhHQhHFpaqIFRrInko1FHXjTRpjWRuWfA==
+jest-validate@^29.7.0:
+  version "29.7.0"
+  resolved "https://registry.yarnpkg.com/jest-validate/-/jest-validate-29.7.0.tgz#7bf705511c64da591d46b15fce41400d52147d9c"
+  integrity sha512-ZB7wHqaRGVw/9hST/OuFUReG7M8vKeq0/J2egIGLdvjHCmYqGARhzXmtgi+gVeZ5uXFF219aOc3Ls2yLg27tkw==
   dependencies:
-    "@jest/types" "^27.0.6"
+    "@jest/types" "^29.6.3"
     camelcase "^6.2.0"
     chalk "^4.0.0"
-    jest-get-type "^27.0.6"
+    jest-get-type "^29.6.3"
     leven "^3.1.0"
-    pretty-format "^27.0.6"
+    pretty-format "^29.7.0"
 
-jest-watcher@^27.0.6:
-  version "27.0.6"
-  resolved "https://registry.yarnpkg.com/jest-watcher/-/jest-watcher-27.0.6.tgz#89526f7f9edf1eac4e4be989bcb6dec6b8878d9c"
-  integrity sha512-/jIoKBhAP00/iMGnTwUBLgvxkn7vsOweDrOTSPzc7X9uOyUtJIDthQBTI1EXz90bdkrxorUZVhJwiB69gcHtYQ==
+jest-watcher@^29.7.0:
+  version "29.7.0"
+  resolved "https://registry.yarnpkg.com/jest-watcher/-/jest-watcher-29.7.0.tgz#7810d30d619c3a62093223ce6bb359ca1b28a2f2"
+  integrity sha512-49Fg7WXkU3Vl2h6LbLtMQ/HyB6rXSIX7SqvBLQmssRBGN9I0PNvPmAmCWSOY6SOvrjhI/F7/bGAv9RtnsPA03g==
   dependencies:
-    "@jest/test-result" "^27.0.6"
-    "@jest/types" "^27.0.6"
+    "@jest/test-result" "^29.7.0"
+    "@jest/types" "^29.6.3"
     "@types/node" "*"
     ansi-escapes "^4.2.1"
     chalk "^4.0.0"
-    jest-util "^27.0.6"
+    emittery "^0.13.1"
+    jest-util "^29.7.0"
     string-length "^4.0.1"
 
 jest-worker@^26.6.2:
@@ -3063,28 +3307,25 @@ jest-worker@^26.6.2:
     merge-stream "^2.0.0"
     supports-color "^7.0.0"
 
-jest-worker@^27.0.6:
-  version "27.0.6"
-  resolved "https://registry.yarnpkg.com/jest-worker/-/jest-worker-27.0.6.tgz#a5fdb1e14ad34eb228cfe162d9f729cdbfa28aed"
-  integrity sha512-qupxcj/dRuA3xHPMUd40gr2EaAurFbkwzOh7wfPaeE9id7hyjURRQoqNfHifHK3XjJU6YJJUQKILGUnwGPEOCA==
+jest-worker@^29.7.0:
+  version "29.7.0"
+  resolved "https://registry.yarnpkg.com/jest-worker/-/jest-worker-29.7.0.tgz#acad073acbbaeb7262bd5389e1bcf43e10058d4a"
+  integrity sha512-eIz2msL/EzL9UFTFFx7jBTkeZfku0yUAyZZZmJ93H2TYEiroIx2PQjEXcwYtYl8zXCxb+PAmA2hLIt/6ZEkPHw==
   dependencies:
     "@types/node" "*"
+    jest-util "^29.7.0"
     merge-stream "^2.0.0"
     supports-color "^8.0.0"
 
-jest@^27.0.4:
-  version "27.0.4"
-  resolved "https://registry.yarnpkg.com/jest/-/jest-27.0.4.tgz#91d4d564b36bcf93b98dac1ab19f07089e670f53"
-  integrity sha512-Px1iKFooXgGSkk1H8dJxxBIrM3tsc5SIuI4kfKYK2J+4rvCvPGr/cXktxh0e9zIPQ5g09kOMNfHQEmusBUf/ZA==
+jest@^29.7.0:
+  version "29.7.0"
+  resolved "https://registry.yarnpkg.com/jest/-/jest-29.7.0.tgz#994676fc24177f088f1c5e3737f5697204ff2613"
+  integrity sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==
   dependencies:
-    "@jest/core" "^27.0.4"
+    "@jest/core" "^29.7.0"
+    "@jest/types" "^29.6.3"
     import-local "^3.0.2"
-    jest-cli "^27.0.4"
-
-jmespath@0.15.0:
-  version "0.15.0"
-  resolved "https://registry.yarnpkg.com/jmespath/-/jmespath-0.15.0.tgz#a3f222a9aae9f966f5d27c796510e28091764217"
-  integrity sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc=
+    jest-cli "^29.7.0"
 
 js-tokens@^4.0.0:
   version "4.0.0"
@@ -3099,55 +3340,25 @@ js-yaml@^3.13.0, js-yaml@^3.13.1, js-yaml@^3.6.1:
     argparse "^1.0.7"
     esprima "^4.0.0"
 
-jsdom@^16.6.0:
-  version "16.6.0"
-  resolved "https://registry.yarnpkg.com/jsdom/-/jsdom-16.6.0.tgz#f79b3786682065492a3da6a60a4695da983805ac"
-  integrity sha512-Ty1vmF4NHJkolaEmdjtxTfSfkdb8Ywarwf63f+F8/mDD1uLSSWDxDuMiZxiPhwunLrn9LOSVItWj4bLYsLN3Dg==
-  dependencies:
-    abab "^2.0.5"
-    acorn "^8.2.4"
-    acorn-globals "^6.0.0"
-    cssom "^0.4.4"
-    cssstyle "^2.3.0"
-    data-urls "^2.0.0"
-    decimal.js "^10.2.1"
-    domexception "^2.0.1"
-    escodegen "^2.0.0"
-    form-data "^3.0.0"
-    html-encoding-sniffer "^2.0.1"
-    http-proxy-agent "^4.0.1"
-    https-proxy-agent "^5.0.0"
-    is-potential-custom-element-name "^1.0.1"
-    nwsapi "^2.2.0"
-    parse5 "6.0.1"
-    saxes "^5.0.1"
-    symbol-tree "^3.2.4"
-    tough-cookie "^4.0.0"
-    w3c-hr-time "^1.0.2"
-    w3c-xmlserializer "^2.0.0"
-    webidl-conversions "^6.1.0"
-    whatwg-encoding "^1.0.5"
-    whatwg-mimetype "^2.3.0"
-    whatwg-url "^8.5.0"
-    ws "^7.4.5"
-    xml-name-validator "^3.0.0"
-
 jsesc@^2.5.1:
   version "2.5.2"
   resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-2.5.2.tgz#80564d2e483dacf6e8ef209650a67df3f0c283a4"
   integrity sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==
+
+jsesc@^3.0.2:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-3.1.0.tgz#74d335a234f67ed19907fdadfac7ccf9d409825d"
+  integrity sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==
 
 json-parse-even-better-errors@^2.3.0:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz#7c47805a94319928e05777405dc12e1f7a4ee02d"
   integrity sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==
 
-json5@2.x, json5@^2.1.2:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/json5/-/json5-2.2.0.tgz#2dfefe720c6ba525d9ebd909950f0515316c89a3"
-  integrity sha512-f+8cldu7X/y7RAJurMEJmdoKXGB/X550w2Nr3tTbezL6RwEE/iMcm+tZnXeoZtKuOq6ft8+CqzEkrIgx1fPoQA==
-  dependencies:
-    minimist "^1.2.5"
+json5@^2.2.3:
+  version "2.2.3"
+  resolved "https://registry.yarnpkg.com/json5/-/json5-2.2.3.tgz#78cd6f1a19bdc12b73db5ad0c61efd66c1e29283"
+  integrity sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==
 
 jsonfile@^4.0.0:
   version "4.0.0"
@@ -3190,14 +3401,6 @@ leven@^3.1.0:
   resolved "https://registry.yarnpkg.com/leven/-/leven-3.1.0.tgz#77891de834064cccba82ae7842bb6b14a13ed7f2"
   integrity sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==
 
-levn@~0.3.0:
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/levn/-/levn-0.3.0.tgz#3b09924edf9f083c0490fdd4c0bc4421e04764ee"
-  integrity sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=
-  dependencies:
-    prelude-ls "~1.1.2"
-    type-check "~0.3.2"
-
 lines-and-columns@^1.1.6:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/lines-and-columns/-/lines-and-columns-1.1.6.tgz#1c00c743b433cd0a4e80758f7b64a57440d9ff00"
@@ -3227,20 +3430,15 @@ locate-path@^6.0.0:
   dependencies:
     p-locate "^5.0.0"
 
-lodash.memoize@4.x:
+lodash.memoize@^4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/lodash.memoize/-/lodash.memoize-4.1.2.tgz#bcc6c49a42a2840ed997f323eada5ecd182e0bfe"
-  integrity sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=
+  integrity sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag==
 
 lodash.startcase@^4.4.0:
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/lodash.startcase/-/lodash.startcase-4.4.0.tgz#9436e34ed26093ed7ffae1936144350915d9add8"
   integrity sha1-lDbjTtJgk+1/+uGTYUQ1CRXZrdg=
-
-lodash@4.x, lodash@^4.7.0:
-  version "4.17.21"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
-  integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
 
 lru-cache@^4.0.1:
   version "4.1.5"
@@ -3249,6 +3447,13 @@ lru-cache@^4.0.1:
   dependencies:
     pseudomap "^1.0.2"
     yallist "^2.1.2"
+
+lru-cache@^5.1.1:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-5.1.1.tgz#1da27e6710271947695daf6848e847f01d84b920"
+  integrity sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==
+  dependencies:
+    yallist "^3.0.2"
 
 lru-cache@^6.0.0:
   version "6.0.0"
@@ -3264,10 +3469,17 @@ make-dir@^3.0.0:
   dependencies:
     semver "^6.0.0"
 
-make-error@1.x:
+make-error@^1.3.6:
   version "1.3.6"
   resolved "https://registry.yarnpkg.com/make-error/-/make-error-1.3.6.tgz#2eb2e37ea9b67c4891f684a1394799af484cf7a2"
   integrity sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==
+
+makeerror@1.0.12:
+  version "1.0.12"
+  resolved "https://registry.yarnpkg.com/makeerror/-/makeerror-1.0.12.tgz#3e5dd2079a82e812e983cc6610c4a2cb0eaa801a"
+  integrity sha512-JmqCvUhmt43madlpFzG4BQzG2Z3m6tvQDNKdClZnO3VbIudJYmxsT0FNJMeiB2+JTSlTQTSbU8QdesVmwJcmLg==
+  dependencies:
+    tmpl "1.0.5"
 
 makeerror@1.0.x:
   version "1.0.11"
@@ -3352,18 +3564,6 @@ micromatch@^4.0.2, micromatch@^4.0.4:
     braces "^3.0.1"
     picomatch "^2.2.3"
 
-mime-db@1.48.0:
-  version "1.48.0"
-  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.48.0.tgz#e35b31045dd7eada3aaad537ed88a33afbef2d1d"
-  integrity sha512-FM3QwxV+TnZYQ2aRqhlKBMHxk10lTbMt3bBkMAp54ddrNeVSfcQYOOKuGuy3Ddrm38I04If834fOUSq1yzslJQ==
-
-mime-types@^2.1.12:
-  version "2.1.31"
-  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.31.tgz#a00d76b74317c61f9c2db2218b8e9f8e9c5c9e6b"
-  integrity sha512-XGZnNzm3QvgKxa8dpzyhFTHmpP3l5YNusmne07VUOXxou9CqUqYa/HBy124RqtVh/O2pECas/MOcsDgpilPOPg==
-  dependencies:
-    mime-db "1.48.0"
-
 mimic-fn@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-2.1.0.tgz#7ed2c2ccccaf84d3ffcb7a69b57711fc2083401b"
@@ -3408,10 +3608,12 @@ mixme@^0.5.0:
   resolved "https://registry.yarnpkg.com/mixme/-/mixme-0.5.1.tgz#b3da79a563b2da46efba9519830059e4c2a9e40f"
   integrity sha512-NaeZIckeBFT7i0XBEpGyFcAE0/bLcQ9MHErTpnU3bLWVE5WZbxG5Y3fDsMxYGifTo5khDA42OquXCC2ngKJB+g==
 
-mkdirp@1.x:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-1.0.4.tgz#3eb5ed62622756d79a5f0e2a221dfebad75c2f7e"
-  integrity sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==
+mnemonist@0.38.3:
+  version "0.38.3"
+  resolved "https://registry.yarnpkg.com/mnemonist/-/mnemonist-0.38.3.tgz#35ec79c1c1f4357cfda2fe264659c2775ccd7d9d"
+  integrity sha512-2K9QYubXx/NAjv4VLq1d1Ly8pWNC5L3BrixtdkyTegXWJIqY+zLNDhhX/A+ZwWt70tB1S8H4BE8FLYEFyNoOBw==
+  dependencies:
+    obliterator "^1.6.1"
 
 mockdate@^3.0.5:
   version "3.0.5"
@@ -3432,6 +3634,11 @@ ms@2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.2.tgz#d09d1f357b443f493382a8eb3ccd183872ae6009"
   integrity sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
+
+ms@^2.1.3:
+  version "2.1.3"
+  resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"
+  integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
 
 nanomatch@^1.2.9:
   version "1.2.13"
@@ -3455,6 +3662,11 @@ natural-compare@^1.4.0:
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
   integrity sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=
 
+neo-async@^2.6.2:
+  version "2.6.2"
+  resolved "https://registry.yarnpkg.com/neo-async/-/neo-async-2.6.2.tgz#b4aafb93e3aeb2d8174ca53cf163ab7d7308305f"
+  integrity sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==
+
 newtype-ts@^0.3.5:
   version "0.3.5"
   resolved "https://registry.yarnpkg.com/newtype-ts/-/newtype-ts-0.3.5.tgz#5c113d34a04938d9e90061437638260ea965c490"
@@ -3470,15 +3682,10 @@ node-int64@^0.4.0:
   resolved "https://registry.yarnpkg.com/node-int64/-/node-int64-0.4.0.tgz#87a9065cdb355d3182d8f94ce11188b825c68a3b"
   integrity sha1-h6kGXNs1XTGC2PlM4RGIuCXGijs=
 
-node-modules-regexp@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/node-modules-regexp/-/node-modules-regexp-1.0.0.tgz#8d9dbe28964a4ac5712e9131642107c71e90ec40"
-  integrity sha1-jZ2+KJZKSsVxLpExZCEHxx6Q7EA=
-
-node-releases@^1.1.71:
-  version "1.1.73"
-  resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-1.1.73.tgz#dd4e81ddd5277ff846b80b52bb40c49edf7a7b20"
-  integrity sha512-uW7fodD6pyW2FZNZnp/Z3hvWKeEW1Y8R1+1CnErE8cXFXzl5blBOoVB41CvMer6P6Q0S5FXDwcHgFd1Wj0U9zg==
+node-releases@^2.0.36:
+  version "2.0.47"
+  resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-2.0.47.tgz#521bb2786da8eb140b748841c0b3b3a75334ffc4"
+  integrity sha512-Uzmd6LXpouKo8EUK68IjH4+E01w/hXyV3R3g/geCJo+rXLNfh1xucB+LOzYEOQPSiUK3h/xZf0cQGcSsmyL2Og==
 
 normalize-package-data@^2.5.0:
   version "2.5.0"
@@ -3516,11 +3723,6 @@ npm-run-path@^4.0.1:
   dependencies:
     path-key "^3.0.0"
 
-nwsapi@^2.2.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/nwsapi/-/nwsapi-2.2.0.tgz#204879a9e3d068ff2a55139c2c772780681a38b7"
-  integrity sha512-h2AatdwYH+JHiZpv7pt/gSX1XoRGb7L/qSIeuqA6GwYoF9w1vP1cw42TO0aI2pNyshRK5893hNSl+1//vHK7hQ==
-
 object-copy@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/object-copy/-/object-copy-0.1.0.tgz#7e7d858b781bd7c991a41ba975ed3812754e998c"
@@ -3544,6 +3746,11 @@ object.pick@^1.3.0:
   dependencies:
     isobject "^3.0.1"
 
+obliterator@^1.6.1:
+  version "1.6.1"
+  resolved "https://registry.yarnpkg.com/obliterator/-/obliterator-1.6.1.tgz#dea03e8ab821f6c4d96a299e17aef6a3af994ef3"
+  integrity sha512-9WXswnqINnnhOG/5SLimUlzuU1hFJUc8zkwyD59Sd+dPOMf05PmnYG/d6Q7HZ+KmgkZJa1PxRso6QdM3sTNHig==
+
 once@^1.3.0, once@^1.3.1, once@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/once/-/once-1.4.0.tgz#583b1aa775961d4b113ac17d9c50baef9dd76bd1"
@@ -3558,18 +3765,6 @@ onetime@^5.1.2:
   dependencies:
     mimic-fn "^2.1.0"
 
-optionator@^0.8.1:
-  version "0.8.3"
-  resolved "https://registry.yarnpkg.com/optionator/-/optionator-0.8.3.tgz#84fa1d036fe9d3c7e21d99884b601167ec8fb495"
-  integrity sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==
-  dependencies:
-    deep-is "~0.1.3"
-    fast-levenshtein "~2.0.6"
-    levn "~0.3.0"
-    prelude-ls "~1.1.2"
-    type-check "~0.3.2"
-    word-wrap "~1.2.3"
-
 os-tmpdir@~1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/os-tmpdir/-/os-tmpdir-1.0.2.tgz#bbe67406c79aa85c5cfec766fe5734555dfa1274"
@@ -3579,11 +3774,6 @@ outdent@^0.5.0:
   version "0.5.0"
   resolved "https://registry.yarnpkg.com/outdent/-/outdent-0.5.0.tgz#9e10982fdc41492bb473ad13840d22f9655be2ff"
   integrity sha512-/jHxFIzoMXdqPzTaCpFzAAWhpkSjZPF4Vsn6jAfNpmbH/ymsmd7Qc6VE9BGn0L6YMj6uwpQLxCECpus4ukKS9Q==
-
-p-each-series@^2.1.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/p-each-series/-/p-each-series-2.2.0.tgz#105ab0357ce72b202a8a8b94933672657b5e2a9a"
-  integrity sha512-ycIL2+1V32th+8scbpTvyHNaHe02z0sjgh91XXjAk+ZeXoPN4Z46DVUnzdso0aX4KckKw0FNNFHdjZ2UsZvxiA==
 
 p-filter@^2.1.0:
   version "2.1.0"
@@ -3604,7 +3794,7 @@ p-limit@^2.2.0:
   dependencies:
     p-try "^2.0.0"
 
-p-limit@^3.0.2:
+p-limit@^3.0.2, p-limit@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-3.1.0.tgz#e1daccbe78d0d1388ca18c64fea38e3e57e3706b"
   integrity sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==
@@ -3635,7 +3825,7 @@ p-try@^2.0.0:
   resolved "https://registry.yarnpkg.com/p-try/-/p-try-2.2.0.tgz#cb2868540e313d61de58fafbe35ce9004d5540e6"
   integrity sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==
 
-parse-json@^5.0.0:
+parse-json@^5.0.0, parse-json@^5.2.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/parse-json/-/parse-json-5.2.0.tgz#c76fc66dee54231c962b22bcc8a72cf2f99753cd"
   integrity sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==
@@ -3644,11 +3834,6 @@ parse-json@^5.0.0:
     error-ex "^1.3.1"
     json-parse-even-better-errors "^2.3.0"
     lines-and-columns "^1.1.6"
-
-parse5@6.0.1:
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/parse5/-/parse5-6.0.1.tgz#e1a1c085c569b3dc08321184f19a39cc27f7c30b"
-  integrity sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw==
 
 pascalcase@^0.1.1:
   version "0.1.1"
@@ -3659,6 +3844,11 @@ path-exists@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/path-exists/-/path-exists-4.0.0.tgz#513bdbe2d3b95d7762e8c1137efa195c6c61b5b3"
   integrity sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==
+
+path-expression-matcher@^1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz#3b98545dc88ffebb593e2d8458d0929da9275f4a"
+  integrity sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==
 
 path-is-absolute@^1.0.0:
   version "1.0.1"
@@ -3685,6 +3875,11 @@ path-type@^4.0.0:
   resolved "https://registry.yarnpkg.com/path-type/-/path-type-4.0.0.tgz#84ed01c0a7ba380afe09d90a8c180dcd9d03043b"
   integrity sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==
 
+picocolors@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/picocolors/-/picocolors-1.1.1.tgz#3d321af3eab939b083c8f929a1d12cda81c26b6b"
+  integrity sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==
+
 picomatch@^2.0.4, picomatch@^2.2.3:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.0.tgz#f1f061de8f6a4bf022892e2d128234fb98302972"
@@ -3695,12 +3890,10 @@ pify@^4.0.1:
   resolved "https://registry.yarnpkg.com/pify/-/pify-4.0.1.tgz#4b2cd25c50d598735c50292224fd8c6df41e3231"
   integrity sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==
 
-pirates@^4.0.1:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/pirates/-/pirates-4.0.1.tgz#643a92caf894566f91b2b986d2c66950a8e2fb87"
-  integrity sha512-WuNqLTbMI3tmfef2TKxlQmAiLHKtFhlsCZnPIpuv2Ow0RDVO8lfy1Opf4NUzlMXLjPl+Men7AuVdX6TA+s+uGA==
-  dependencies:
-    node-modules-regexp "^1.0.0"
+pirates@^4.0.4:
+  version "4.0.7"
+  resolved "https://registry.yarnpkg.com/pirates/-/pirates-4.0.7.tgz#643b4a18c4257c8a65104b73f3049ce9a0a15e22"
+  integrity sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==
 
 pkg-dir@^4.2.0:
   version "4.2.0"
@@ -3724,11 +3917,6 @@ preferred-pm@^3.0.0:
     path-exists "^4.0.0"
     which-pm "2.0.0"
 
-prelude-ls@~1.1.2:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.1.2.tgz#21932a549f5e52ffd9a827f570e04be62a97da54"
-  integrity sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=
-
 prettier@^1.19.1:
   version "1.19.1"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.19.1.tgz#f7d7f5ff8a9cd872a7be4ca142095956a60797cb"
@@ -3739,7 +3927,7 @@ prettier@^2.2.1:
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.3.2.tgz#ef280a05ec253712e486233db5c6f23441e7342d"
   integrity sha512-lnJzDfJ66zkMy58OL5/NY5zp70S7Nz6KqcKkXYzn2tMVrNxvbqaBpg7H3qHaLxCJ5lNMsGuM8+ohS7cZrthdLQ==
 
-pretty-format@^26.0.0, pretty-format@^26.1.0, pretty-format@^26.6.2:
+pretty-format@^26.1.0, pretty-format@^26.6.2:
   version "26.6.2"
   resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-26.6.2.tgz#e35c2705f14cb7fe2fe94fa078345b444120fc93"
   integrity sha512-7AeGuCYNGmycyQbCqd/3PWH4eOoX/OiCa0uphp57NVTeAGdJGaAliecxwBDHYQCIvrW7aDBZCYeNTP/WX69mkg==
@@ -3749,24 +3937,14 @@ pretty-format@^26.0.0, pretty-format@^26.1.0, pretty-format@^26.6.2:
     ansi-styles "^4.0.0"
     react-is "^17.0.1"
 
-pretty-format@^27.0.0, pretty-format@^27.5.1:
-  version "27.5.1"
-  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-27.5.1.tgz#2181879fdea51a7a5851fb39d920faa63f01d88e"
-  integrity sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==
+pretty-format@^29.0.0, pretty-format@^29.7.0:
+  version "29.7.0"
+  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-29.7.0.tgz#ca42c758310f365bfa71a0bda0a807160b776812"
+  integrity sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==
   dependencies:
-    ansi-regex "^5.0.1"
+    "@jest/schemas" "^29.6.3"
     ansi-styles "^5.0.0"
-    react-is "^17.0.1"
-
-pretty-format@^27.0.6:
-  version "27.0.6"
-  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-27.0.6.tgz#ab770c47b2c6f893a21aefc57b75da63ef49a11f"
-  integrity sha512-8tGD7gBIENgzqA+UBzObyWqQ5B778VIFZA/S66cclyd5YkFLYs2Js7gxDKf0MXtTc9zcS7t1xhdfcElJ3YIvkQ==
-  dependencies:
-    "@jest/types" "^27.0.6"
-    ansi-regex "^5.0.0"
-    ansi-styles "^5.0.0"
-    react-is "^17.0.1"
+    react-is "^18.0.0"
 
 prompts@^2.0.1:
   version "2.4.1"
@@ -3781,11 +3959,6 @@ pseudomap@^1.0.2:
   resolved "https://registry.yarnpkg.com/pseudomap/-/pseudomap-1.0.2.tgz#f052a28da70e618917ef0a8ac34c1ae5a68286b3"
   integrity sha1-8FKijacOYYkX7wqKw0wa5aaChrM=
 
-psl@^1.1.33:
-  version "1.8.0"
-  resolved "https://registry.yarnpkg.com/psl/-/psl-1.8.0.tgz#9326f8bcfb013adcc005fdff056acce020e51c24"
-  integrity sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ==
-
 pump@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/pump/-/pump-3.0.0.tgz#b4a2116815bde2f4e1ea602354e8c75565107a64"
@@ -3794,20 +3967,10 @@ pump@^3.0.0:
     end-of-stream "^1.1.0"
     once "^1.3.1"
 
-punycode@1.3.2:
-  version "1.3.2"
-  resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.3.2.tgz#9653a036fb7c1ee42342f2325cceefea3926c48d"
-  integrity sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0=
-
-punycode@^2.1.1:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
-  integrity sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==
-
-querystring@0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/querystring/-/querystring-0.2.0.tgz#b209849203bb25df820da756e747005878521620"
-  integrity sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=
+pure-rand@^6.0.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/pure-rand/-/pure-rand-6.1.0.tgz#d173cf23258231976ccbdb05247c9787957604f2"
+  integrity sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==
 
 queue-microtask@^1.2.2:
   version "1.2.3"
@@ -3823,6 +3986,11 @@ react-is@^17.0.1:
   version "17.0.2"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-17.0.2.tgz#e691d4a8e9c789365655539ab372762b0efb54f0"
   integrity sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==
+
+react-is@^18.0.0:
+  version "18.3.1"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-18.3.1.tgz#e83557dc12eae63a99e003a46388b1dcbb44db7e"
+  integrity sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==
 
 read-pkg-up@^7.0.1:
   version "7.0.1"
@@ -3916,6 +4084,11 @@ resolve-url@^0.2.1:
   resolved "https://registry.yarnpkg.com/resolve-url/-/resolve-url-0.2.1.tgz#2c637fe77c893afd2a663fe21aa9080068e2052a"
   integrity sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=
 
+resolve.exports@^2.0.0:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/resolve.exports/-/resolve.exports-2.0.3.tgz#41955e6f1b4013b7586f873749a635dea07ebe3f"
+  integrity sha512-OcXjMsGdhL4XnbShKpAcSqPMzQoYkYyhbEaeSko47MjRP9NfEQMhZkXL1DoFlt9LWQn4YttrdnV6X2OiyzBi+A==
+
 resolve@^1.10.0, resolve@^1.18.1, resolve@^1.20.0:
   version "1.20.0"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.20.0.tgz#629a013fb3f70755d6f0b7935cc1c2c5378b1975"
@@ -3939,13 +4112,6 @@ reusify@^1.0.4:
   resolved "https://registry.yarnpkg.com/reusify/-/reusify-1.0.4.tgz#90da382b1e126efc02146e90845a88db12925d76"
   integrity sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==
 
-rimraf@^3.0.0:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-3.0.2.tgz#f1a5402ba6220ad52cc1282bac1ae3aa49fd061a"
-  integrity sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==
-  dependencies:
-    glob "^7.1.3"
-
 rsvp@^4.8.4:
   version "4.8.5"
   resolved "https://registry.yarnpkg.com/rsvp/-/rsvp-4.8.5.tgz#c8f155311d167f68f21e168df71ec5b083113734"
@@ -3957,11 +4123,6 @@ run-parallel@^1.1.9:
   integrity sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==
   dependencies:
     queue-microtask "^1.2.2"
-
-safe-buffer@~5.1.1:
-  version "5.1.2"
-  resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
-  integrity sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==
 
 safe-regex@^1.1.0:
   version "1.1.0"
@@ -3990,39 +4151,32 @@ sane@^4.0.3:
     minimist "^1.1.1"
     walker "~1.0.5"
 
-sax@1.2.1:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.1.tgz#7b8e656190b228e81a66aea748480d828cd2d37a"
-  integrity sha1-e45lYZCyKOgaZq6nSEgNgozS03o=
-
-sax@>=0.6.0:
-  version "1.2.4"
-  resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
-  integrity sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==
-
-saxes@^5.0.1:
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/saxes/-/saxes-5.0.1.tgz#eebab953fa3b7608dbe94e5dadb15c888fa6696d"
-  integrity sha512-5LBh1Tls8c9xgGjw3QrMwETmTMVk0oFgvrFSvWx62llR2hcEInrKNZ2GZCCuuy2lvWrdl5jhbpeqc5hRYKFOcw==
-  dependencies:
-    xmlchars "^2.2.0"
-
 "semver@2 || 3 || 4 || 5", semver@^5.4.1, semver@^5.5.0:
   version "5.7.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.1.tgz#a954f931aeba508d307bbf069eff0c01c96116f7"
   integrity sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==
 
-semver@7.x, semver@^7.3.2:
+semver@^6.0.0, semver@^6.3.0:
+  version "6.3.0"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
+  integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
+
+semver@^6.3.1:
+  version "6.3.1"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.1.tgz#556d2ef8689146e46dcea4bfdd095f3434dffcb4"
+  integrity sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==
+
+semver@^7.3.2:
   version "7.3.5"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.5.tgz#0b621c879348d8998e4b0e4be94b3f12e6018ef7"
   integrity sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==
   dependencies:
     lru-cache "^6.0.0"
 
-semver@^6.0.0, semver@^6.3.0:
-  version "6.3.0"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
-  integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
+semver@^7.5.3, semver@^7.5.4, semver@^7.8.0:
+  version "7.8.4"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.8.4.tgz#c73eceebae0616934be8dff28a7fd70757c8e696"
+  integrity sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==
 
 set-blocking@^2.0.0:
   version "2.0.0"
@@ -4067,6 +4221,11 @@ signal-exit@^3.0.0, signal-exit@^3.0.2, signal-exit@^3.0.3:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.3.tgz#a1410c2edd8f077b08b4e253c8eacfcaf057461c"
   integrity sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==
+
+signal-exit@^3.0.7:
+  version "3.0.7"
+  resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.7.tgz#a9a1767f8af84155114eaabd73f99273c8f59ad9"
+  integrity sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==
 
 sisteransi@^1.0.5:
   version "1.0.5"
@@ -4139,10 +4298,10 @@ source-map-resolve@^0.5.0:
     source-map-url "^0.4.0"
     urix "^0.1.0"
 
-source-map-support@^0.5.6:
-  version "0.5.19"
-  resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.19.tgz#a98b62f86dcaf4f67399648c085291ab9e8fed61"
-  integrity sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==
+source-map-support@0.5.13:
+  version "0.5.13"
+  resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.13.tgz#31b24a9c2e73c2de85066c0feb7d44767ed52932"
+  integrity sha512-SHSKFHadjVA5oR4PPqhtAVdcBWwRYVd6g6cAXnIbRiIwc2EhPrTuKUBdSLvlEKyIP3GCf89fltvcZiP9MMFA1w==
   dependencies:
     buffer-from "^1.0.0"
     source-map "^0.6.0"
@@ -4157,15 +4316,10 @@ source-map@^0.5.0, source-map@^0.5.6:
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.7.tgz#8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc"
   integrity sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=
 
-source-map@^0.6.0, source-map@^0.6.1, source-map@~0.6.1:
+source-map@^0.6.0, source-map@^0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
   integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
-
-source-map@^0.7.3:
-  version "0.7.3"
-  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.7.3.tgz#5302f8169031735226544092e64981f751750383"
-  integrity sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==
 
 spawndamnit@^2.0.0:
   version "2.0.0"
@@ -4260,6 +4414,15 @@ string-width@^4.1.0, string-width@^4.2.0:
     is-fullwidth-code-point "^3.0.0"
     strip-ansi "^6.0.0"
 
+string-width@^4.2.3:
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
+
 strip-ansi@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-4.0.0.tgz#a8479022eb1ac368a871389b635262c505ee368f"
@@ -4273,6 +4436,13 @@ strip-ansi@^6.0.0:
   integrity sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==
   dependencies:
     ansi-regex "^5.0.0"
+
+strip-ansi@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
 
 strip-bom@^3.0.0:
   version "3.0.0"
@@ -4301,6 +4471,18 @@ strip-indent@^3.0.0:
   dependencies:
     min-indent "^1.0.0"
 
+strip-json-comments@^3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-3.1.1.tgz#31f1281b3832630434831c310c01cccda8cbe006"
+  integrity sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==
+
+strnum@^2.2.3:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/strnum/-/strnum-2.4.0.tgz#304881c3299b017855f1934a4ce85bfb60b1ca2a"
+  integrity sha512-sHrVyWWdq28RbhjuJdZsA1SnGRJV6NiXbk6AXBxDOsgAcA+lmpUZCYjOdLBxkXMwis6RRe7dlZt4VlIWFVzkmg==
+  dependencies:
+    anynum "^1.0.0"
+
 supports-color@^5.3.0:
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-5.5.0.tgz#e2e69a44ac8772f78a1ec0b35b689df6530efc8f"
@@ -4322,19 +4504,6 @@ supports-color@^8.0.0:
   dependencies:
     has-flag "^4.0.0"
 
-supports-hyperlinks@^2.0.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/supports-hyperlinks/-/supports-hyperlinks-2.2.0.tgz#4f77b42488765891774b70c79babd87f9bd594bb"
-  integrity sha512-6sXEzV5+I5j8Bmq9/vUphGRM/RJNT9SCURJLjwfOg51heRtguGWDzcaBlgAzKhQa0EVNpPEKzQuBwZ8S8WaCeQ==
-  dependencies:
-    has-flag "^4.0.0"
-    supports-color "^7.0.0"
-
-symbol-tree@^3.2.4:
-  version "3.2.4"
-  resolved "https://registry.yarnpkg.com/symbol-tree/-/symbol-tree-3.2.4.tgz#430637d248ba77e078883951fb9aa0eed7c63fa2"
-  integrity sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==
-
 term-size@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/term-size/-/term-size-1.2.0.tgz#458b83887f288fc56d6fffbfad262e26638efa69"
@@ -4347,14 +4516,6 @@ term-size@^2.1.0:
   resolved "https://registry.yarnpkg.com/term-size/-/term-size-2.2.1.tgz#2a6a54840432c2fb6320fea0f415531e90189f54"
   integrity sha512-wK0Ri4fOGjv/XPy8SBHZChl8CM7uMc5VML7SqiQ0zG7+J5Vr+RMQDoHa2CNT6KHUnTGIXH34UDMkPzAUyapBZg==
 
-terminal-link@^2.0.0:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/terminal-link/-/terminal-link-2.1.1.tgz#14a64a27ab3c0df933ea546fba55f2d078edc994"
-  integrity sha512-un0FmiRUQNr5PJqy9kP7c40F5BOfpGlYTrxonDChEZB7pzZxRNp/bt+ymiy9/npwXya9KH99nJ/GXFIiUkYGFQ==
-  dependencies:
-    ansi-escapes "^4.2.1"
-    supports-hyperlinks "^2.0.0"
-
 test-exclude@^6.0.0:
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/test-exclude/-/test-exclude-6.0.0.tgz#04a8698661d805ea6fa293b6cb9e63ac044ef15e"
@@ -4364,17 +4525,17 @@ test-exclude@^6.0.0:
     glob "^7.1.4"
     minimatch "^3.0.4"
 
-throat@^6.0.1:
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/throat/-/throat-6.0.1.tgz#d514fedad95740c12c2d7fc70ea863eb51ade375"
-  integrity sha512-8hmiGIJMDlwjg7dlJ4yKGLK8EsYqKgPWbG3b4wjJddKNwc7N7Dpn08Df4szr/sZdMVeOstrdYSsqzX6BYbcB+w==
-
 tmp@^0.0.33:
   version "0.0.33"
   resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.0.33.tgz#6d34335889768d21b2bcda0aa277ced3b1bfadf9"
   integrity sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==
   dependencies:
     os-tmpdir "~1.0.2"
+
+tmpl@1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/tmpl/-/tmpl-1.0.5.tgz#8683e0b902bb9c20c4f726e3c0b69f36518c07cc"
+  integrity sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==
 
 tmpl@1.0.x:
   version "1.0.4"
@@ -4418,61 +4579,35 @@ to-regex@^3.0.1, to-regex@^3.0.2:
     regex-not "^1.0.2"
     safe-regex "^1.1.0"
 
-tough-cookie@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-4.0.0.tgz#d822234eeca882f991f0f908824ad2622ddbece4"
-  integrity sha512-tHdtEpQCMrc1YLrMaqXXcj6AxhYi/xgit6mZu1+EDWUn+qhUf8wMQoFIy9NXuq23zAwtcB0t/MjACGR18pcRbg==
-  dependencies:
-    psl "^1.1.33"
-    punycode "^2.1.1"
-    universalify "^0.1.2"
-
-tr46@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/tr46/-/tr46-2.1.0.tgz#fa87aa81ca5d5941da8cbf1f9b749dc969a4e240"
-  integrity sha512-15Ih7phfcdP5YxqiB+iDtLoaTz4Nd35+IiAv0kQ5FNKHzXgdWqPoTIqEDDJmXceQt4JZk6lVPT8lnDlPpGDppw==
-  dependencies:
-    punycode "^2.1.1"
-
 trim-newlines@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/trim-newlines/-/trim-newlines-3.0.1.tgz#260a5d962d8b752425b32f3a7db0dcacd176c144"
   integrity sha512-c1PTsA3tYrIsLGkJkzHF+w9F2EyxfXGo4UyJc4pFL++FMjnq0HJS69T3M7d//gKrFKwy429bouPescbjecU+Zw==
 
-ts-jest@^27.0.3:
-  version "27.0.3"
-  resolved "https://registry.yarnpkg.com/ts-jest/-/ts-jest-27.0.3.tgz#808492f022296cde19390bb6ad627c8126bf93f8"
-  integrity sha512-U5rdMjnYam9Ucw+h0QvtNDbc5+88nxt7tbIvqaZUhFrfG4+SkWhMXjejCLVGcpILTPuV+H3W/GZDZrnZFpPeXw==
+ts-jest@^29.2.5:
+  version "29.4.11"
+  resolved "https://registry.yarnpkg.com/ts-jest/-/ts-jest-29.4.11.tgz#42f5de21c37ccc01a580253afae6955abbf4d0b3"
+  integrity sha512-IrFl7l9AuB/qrNw5quqvAv/hmKMb8dhWOH4jQOGo0Oq8tCeo1O86/iTFG1FaRimgUkF13l4PcepO8ATFT6Ns4g==
   dependencies:
-    bs-logger "0.x"
-    buffer-from "1.x"
-    fast-json-stable-stringify "2.x"
-    jest-util "^27.0.0"
-    json5 "2.x"
-    lodash "4.x"
-    make-error "1.x"
-    mkdirp "1.x"
-    semver "7.x"
-    yargs-parser "20.x"
-
-ts-jest@^27.1.3:
-  version "27.1.4"
-  resolved "https://registry.yarnpkg.com/ts-jest/-/ts-jest-27.1.4.tgz#84d42cf0f4e7157a52e7c64b1492c46330943e00"
-  integrity sha512-qjkZlVPWVctAezwsOD1OPzbZ+k7zA5z3oxII4dGdZo5ggX/PL7kvwTM0pXTr10fAtbiVpJaL3bWd502zAhpgSQ==
-  dependencies:
-    bs-logger "0.x"
-    fast-json-stable-stringify "2.x"
-    jest-util "^27.0.0"
-    json5 "2.x"
-    lodash.memoize "4.x"
-    make-error "1.x"
-    semver "7.x"
-    yargs-parser "20.x"
+    bs-logger "^0.2.6"
+    fast-json-stable-stringify "^2.1.0"
+    handlebars "^4.7.9"
+    json5 "^2.2.3"
+    lodash.memoize "^4.1.2"
+    make-error "^1.3.6"
+    semver "^7.8.0"
+    type-fest "^4.41.0"
+    yargs-parser "^21.1.1"
 
 tslib@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.3.0.tgz#803b8cdab3e12ba581a4ca41c8839bbb0dacb09e"
   integrity sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg==
+
+tslib@^2.6.2:
+  version "2.8.1"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.8.1.tgz#612efe4ed235d567e8aba5f2a5fab70280ade83f"
+  integrity sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==
 
 tty-table@^2.8.10:
   version "2.8.13"
@@ -4485,13 +4620,6 @@ tty-table@^2.8.10:
     strip-ansi "^6.0.0"
     wcwidth "^1.0.1"
     yargs "^15.1.0"
-
-type-check@~0.3.2:
-  version "0.3.2"
-  resolved "https://registry.yarnpkg.com/type-check/-/type-check-0.3.2.tgz#5884cab512cf1d355e3fb784f30804b2b520db72"
-  integrity sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=
-  dependencies:
-    prelude-ls "~1.1.2"
 
 type-detect@4.0.8:
   version "4.0.8"
@@ -4518,22 +4646,30 @@ type-fest@^0.8.1:
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.8.1.tgz#09e249ebde851d3b1e48d27c105444667f17b83d"
   integrity sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==
 
-typedarray-to-buffer@^3.1.5:
-  version "3.1.5"
-  resolved "https://registry.yarnpkg.com/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz#a97ee7a9ff42691b9f783ff1bc5112fe3fca9080"
-  integrity sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==
-  dependencies:
-    is-typedarray "^1.0.0"
+type-fest@^4.41.0:
+  version "4.41.0"
+  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-4.41.0.tgz#6ae1c8e5731273c2bf1f58ad39cbae2c91a46c58"
+  integrity sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==
 
 typescript-memoize@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/typescript-memoize/-/typescript-memoize-1.0.1.tgz#0a8199aa28f6fe18517f6e9308ef7bfbe9a98d59"
   integrity sha512-oJNge1qUrOK37d5Y6Ly2txKeuelYVsFtNF6U9kXIN7juudcQaHJQg2MxLOy0CqtkW65rVDYuTCOjnSIVPd8z3w==
 
-typescript@4.5.5, typescript@~4.3.5, typescript@~4.5.5:
+typescript@4.5.5, typescript@~4.5.5:
   version "4.5.5"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.5.5.tgz#d8c953832d28924a9e3d37c73d729c846c5896f3"
   integrity sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==
+
+uglify-js@^3.1.4:
+  version "3.19.3"
+  resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.19.3.tgz#82315e9bbc6f2b25888858acd1fff8441035b77f"
+  integrity sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ==
+
+undici-types@~5.26.4:
+  version "5.26.5"
+  resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-5.26.5.tgz#bcd539893d00b56e964fd2657a4866b221a65617"
+  integrity sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==
 
 union-value@^1.0.0:
   version "1.0.1"
@@ -4545,7 +4681,7 @@ union-value@^1.0.0:
     is-extendable "^0.1.1"
     set-value "^2.0.1"
 
-universalify@^0.1.0, universalify@^0.1.2:
+universalify@^0.1.0:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/universalify/-/universalify-0.1.2.tgz#b646f69be3942dabcecc9d6639c80dc105efaa66"
   integrity sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==
@@ -4558,42 +4694,37 @@ unset-value@^1.0.0:
     has-value "^0.3.1"
     isobject "^3.0.0"
 
+update-browserslist-db@^1.2.3:
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz#64d76db58713136acbeb4c49114366cc6cc2e80d"
+  integrity sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==
+  dependencies:
+    escalade "^3.2.0"
+    picocolors "^1.1.1"
+
 urix@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/urix/-/urix-0.1.0.tgz#da937f7a62e21fec1fd18d49b35c2935067a6c72"
   integrity sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=
-
-url@0.10.3:
-  version "0.10.3"
-  resolved "https://registry.yarnpkg.com/url/-/url-0.10.3.tgz#021e4d9c7705f21bbf37d03ceb58767402774c64"
-  integrity sha1-Ah5NnHcF8hu/N9A861h2dAJ3TGQ=
-  dependencies:
-    punycode "1.3.2"
-    querystring "0.2.0"
 
 use@^3.1.0:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/use/-/use-3.1.1.tgz#d50c8cac79a19fbc20f2911f56eb973f4e10070f"
   integrity sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==
 
-uuid@3.3.2:
-  version "3.3.2"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.3.2.tgz#1b4af4955eb3077c501c23872fc6513811587131"
-  integrity sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==
-
 uuid@^8.3.2:
   version "8.3.2"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
   integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
 
-v8-to-istanbul@^8.0.0:
-  version "8.0.0"
-  resolved "https://registry.yarnpkg.com/v8-to-istanbul/-/v8-to-istanbul-8.0.0.tgz#4229f2a99e367f3f018fa1d5c2b8ec684667c69c"
-  integrity sha512-LkmXi8UUNxnCC+JlH7/fsfsKr5AU110l+SYGJimWNkWhxbN5EyeOtm1MJ0hhvqMMOhGwBj1Fp70Yv9i+hX0QAg==
+v8-to-istanbul@^9.0.1:
+  version "9.3.0"
+  resolved "https://registry.yarnpkg.com/v8-to-istanbul/-/v8-to-istanbul-9.3.0.tgz#b9572abfa62bd556c16d75fdebc1a411d5ff3175"
+  integrity sha512-kiGUalWN+rgBJ/1OHZsBtU4rXZOfj/7rKQxULKlIzwzQSvMJUUNgPwJEEh7gU6xEVxC0ahoOBvN2YI8GH6FNgA==
   dependencies:
+    "@jridgewell/trace-mapping" "^0.3.12"
     "@types/istanbul-lib-coverage" "^2.0.1"
-    convert-source-map "^1.6.0"
-    source-map "^0.7.3"
+    convert-source-map "^2.0.0"
 
 validate-npm-package-license@^3.0.1:
   version "3.0.4"
@@ -4603,20 +4734,6 @@ validate-npm-package-license@^3.0.1:
     spdx-correct "^3.0.0"
     spdx-expression-parse "^3.0.0"
 
-w3c-hr-time@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/w3c-hr-time/-/w3c-hr-time-1.0.2.tgz#0a89cdf5cc15822df9c360543676963e0cc308cd"
-  integrity sha512-z8P5DvDNjKDoFIHK7q8r8lackT6l+jo/Ye3HOle7l9nICP9lf1Ci25fy9vHd0JOWewkIFzXIEig3TdKT7JQ5fQ==
-  dependencies:
-    browser-process-hrtime "^1.0.0"
-
-w3c-xmlserializer@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/w3c-xmlserializer/-/w3c-xmlserializer-2.0.0.tgz#3e7104a05b75146cc60f564380b7f683acf1020a"
-  integrity sha512-4tzD0mF8iSiMiNs30BiLO3EpfGLZUT2MSX/G+o7ZywDzliWQ3OPtTZ0PTC3B3ca1UAf4cJMHB+2Bf56EriJuRA==
-  dependencies:
-    xml-name-validator "^3.0.0"
-
 walker@^1.0.7, walker@~1.0.5:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/walker/-/walker-1.0.7.tgz#2f7f9b8fd10d677262b18a884e28d19618e028fb"
@@ -4624,43 +4741,19 @@ walker@^1.0.7, walker@~1.0.5:
   dependencies:
     makeerror "1.0.x"
 
+walker@^1.0.8:
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/walker/-/walker-1.0.8.tgz#bd498db477afe573dc04185f011d3ab8a8d7653f"
+  integrity sha512-ts/8E8l5b7kY0vlWLewOkDXMmPdLcVV4GmOQLyxuSswIJsweeFZtAsMF7k1Nszz+TYBQrlYRmzOnr398y1JemQ==
+  dependencies:
+    makeerror "1.0.12"
+
 wcwidth@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/wcwidth/-/wcwidth-1.0.1.tgz#f0b0dcf915bc5ff1528afadb2c0e17b532da2fe8"
   integrity sha1-8LDc+RW8X/FSivrbLA4XtTLaL+g=
   dependencies:
     defaults "^1.0.3"
-
-webidl-conversions@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-5.0.0.tgz#ae59c8a00b121543a2acc65c0434f57b0fc11aff"
-  integrity sha512-VlZwKPCkYKxQgeSbH5EyngOmRp7Ww7I9rQLERETtf5ofd9pGeswWiOtogpEO850jziPRarreGxn5QIiTqpb2wA==
-
-webidl-conversions@^6.1.0:
-  version "6.1.0"
-  resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-6.1.0.tgz#9111b4d7ea80acd40f5270d666621afa78b69514"
-  integrity sha512-qBIvFLGiBpLjfwmYAaHPXsn+ho5xZnGvyGvsarywGNc8VyQJUMHJ8OBKGGrPER0okBeMDaan4mNBlgBROxuI8w==
-
-whatwg-encoding@^1.0.5:
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/whatwg-encoding/-/whatwg-encoding-1.0.5.tgz#5abacf777c32166a51d085d6b4f3e7d27113ddb0"
-  integrity sha512-b5lim54JOPN9HtzvK9HFXvBma/rnfFeqsic0hSpjtDbVxR3dJKLc+KB4V6GgiGOvl7CY/KNh8rxSo9DKQrnUEw==
-  dependencies:
-    iconv-lite "0.4.24"
-
-whatwg-mimetype@^2.3.0:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/whatwg-mimetype/-/whatwg-mimetype-2.3.0.tgz#3d4b1e0312d2079879f826aff18dbeeca5960fbf"
-  integrity sha512-M4yMwr6mAnQz76TbJm914+gPpB/nCwvZbJU28cUD6dR004SAxDLOOSUaB1JDRqLtaOV/vi0IC5lEAGFgrjGv/g==
-
-whatwg-url@^8.0.0, whatwg-url@^8.5.0:
-  version "8.7.0"
-  resolved "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-8.7.0.tgz#656a78e510ff8f3937bc0bcbe9f5c0ac35941b77"
-  integrity sha512-gAojqb/m9Q8a5IV96E3fHJM70AzCkgt4uXYX2O7EmuyOnLrViCQlsEBmF9UQIu3/aeAIp2U17rtbpZWNntQqdg==
-  dependencies:
-    lodash "^4.7.0"
-    tr46 "^2.1.0"
-    webidl-conversions "^6.1.0"
 
 which-module@^2.0.0:
   version "2.0.0"
@@ -4696,10 +4789,10 @@ widest-line@^2.0.0:
   dependencies:
     string-width "^2.1.1"
 
-word-wrap@~1.2.3:
-  version "1.2.3"
-  resolved "https://registry.yarnpkg.com/word-wrap/-/word-wrap-1.2.3.tgz#610636f6b1f703891bd34771ccb17fb93b47079c"
-  integrity sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==
+wordwrap@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-1.0.0.tgz#27584810891456a4171c8d0226441ade90cbcaeb"
+  integrity sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==
 
 wrap-ansi@^6.2.0:
   version "6.2.0"
@@ -4724,43 +4817,18 @@ wrappy@1:
   resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
   integrity sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=
 
-write-file-atomic@^3.0.0:
-  version "3.0.3"
-  resolved "https://registry.yarnpkg.com/write-file-atomic/-/write-file-atomic-3.0.3.tgz#56bd5c5a5c70481cd19c571bd39ab965a5de56e8"
-  integrity sha512-AvHcyZ5JnSfq3ioSyjrBkH9yW4m7Ayk8/9My/DD9onKeu/94fwrMocemO2QAJFAlnnDN+ZDS+ZjAR5ua1/PV/Q==
+write-file-atomic@^4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/write-file-atomic/-/write-file-atomic-4.0.2.tgz#a9df01ae5b77858a027fd2e80768ee433555fcfd"
+  integrity sha512-7KxauUdBmSdWnmpaGFg+ppNjKF8uNLry8LyzjauQDOVONfFLNKrKvQOxZ/VuTIcS/gge/YNahf5RIIQWTSarlg==
   dependencies:
     imurmurhash "^0.1.4"
-    is-typedarray "^1.0.0"
-    signal-exit "^3.0.2"
-    typedarray-to-buffer "^3.1.5"
+    signal-exit "^3.0.7"
 
-ws@^7.4.5:
-  version "7.5.3"
-  resolved "https://registry.yarnpkg.com/ws/-/ws-7.5.3.tgz#160835b63c7d97bfab418fc1b8a9fced2ac01a74"
-  integrity sha512-kQ/dHIzuLrS6Je9+uv81ueZomEwH0qVYstcAQ4/Z93K8zeko9gtAbttJWzoC5ukqXY1PpoouV3+VSOqEAFt5wg==
-
-xml-name-validator@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/xml-name-validator/-/xml-name-validator-3.0.0.tgz#6ae73e06de4d8c6e47f9fb181f78d648ad457c6a"
-  integrity sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==
-
-xml2js@0.4.19:
-  version "0.4.19"
-  resolved "https://registry.yarnpkg.com/xml2js/-/xml2js-0.4.19.tgz#686c20f213209e94abf0d1bcf1efaa291c7827a7"
-  integrity sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==
-  dependencies:
-    sax ">=0.6.0"
-    xmlbuilder "~9.0.1"
-
-xmlbuilder@~9.0.1:
-  version "9.0.7"
-  resolved "https://registry.yarnpkg.com/xmlbuilder/-/xmlbuilder-9.0.7.tgz#132ee63d2ec5565c557e20f4c22df9aca686b10d"
-  integrity sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0=
-
-xmlchars@^2.2.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/xmlchars/-/xmlchars-2.2.0.tgz#060fe1bcb7f9c76fe2a17db86a9bc3ab894210cb"
-  integrity sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==
+xml-naming@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/xml-naming/-/xml-naming-0.1.0.tgz#8ab7106c5b8d23caa2fabac1cadf17136379fbd8"
+  integrity sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==
 
 y18n@^4.0.0:
   version "4.0.3"
@@ -4777,15 +4845,15 @@ yallist@^2.1.2:
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-2.1.2.tgz#1c11f9218f076089a47dd512f93c6699a6a81d52"
   integrity sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=
 
+yallist@^3.0.2:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/yallist/-/yallist-3.1.1.tgz#dbb7daf9bfd8bac9ab45ebf602b8cbad0d5d08fd"
+  integrity sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==
+
 yallist@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-4.0.0.tgz#9bb92790d9c0effec63be73519e11a35019a3a72"
   integrity sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==
-
-yargs-parser@20.x, yargs-parser@^20.2.2:
-  version "20.2.9"
-  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-20.2.9.tgz#2eb7dc3b0289718fc295f362753845c41a0c94ee"
-  integrity sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==
 
 yargs-parser@^18.1.2, yargs-parser@^18.1.3:
   version "18.1.3"
@@ -4794,6 +4862,11 @@ yargs-parser@^18.1.2, yargs-parser@^18.1.3:
   dependencies:
     camelcase "^5.0.0"
     decamelize "^1.2.0"
+
+yargs-parser@^21.1.1:
+  version "21.1.1"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-21.1.1.tgz#9096bceebf990d21bb31fa9516e0ede294a77d35"
+  integrity sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==
 
 yargs@^15.1.0:
   version "15.4.1"
@@ -4812,18 +4885,18 @@ yargs@^15.1.0:
     y18n "^4.0.0"
     yargs-parser "^18.1.2"
 
-yargs@^16.0.3:
-  version "16.2.0"
-  resolved "https://registry.yarnpkg.com/yargs/-/yargs-16.2.0.tgz#1c82bf0f6b6a66eafce7ef30e376f49a12477f66"
-  integrity sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==
+yargs@^17.3.1:
+  version "17.7.2"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-17.7.2.tgz#991df39aca675a192b816e1e0363f9d75d2aa269"
+  integrity sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==
   dependencies:
-    cliui "^7.0.2"
+    cliui "^8.0.1"
     escalade "^3.1.1"
     get-caller-file "^2.0.5"
     require-directory "^2.1.1"
-    string-width "^4.2.0"
+    string-width "^4.2.3"
     y18n "^5.0.5"
-    yargs-parser "^20.2.2"
+    yargs-parser "^21.1.1"
 
 yocto-queue@^0.1.0:
   version "0.1.0"


### PR DESCRIPTION
## Summary
- Switch `@model-ts/dynamodb` and `@model-ts/eventbridge` to AWS SDK for JavaScript v3.
- Add a thin DynamoDB compat layer so the existing model logic keeps working with minimal churn.
- Update Jest config and test setup to run cleanly against the v3 clients.
- Refresh the READMEs to clearly state the v3 dependency model.

## Testing
- `yarn build`
- `yarn workspace @model-ts/core test --runInBand`
- `yarn workspace @model-ts/eventbridge test --runInBand`
- `yarn workspace @model-ts/dynamodb test --runInBand`